### PR TITLE
Fixing Example to be functional in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ BarcodeLib.Barcode b = new BarcodeLib.Barcode(BarcodeLib.TYPE.UPCA,
 ### Example ###
 ```
 BarcodeLib.Barcode b = new BarcodeLib.Barcode();
-b.Alignment = BarcodeLib.AlignmentPositions.CENTER;
 Image img = b.Encode(BarcodeLib.TYPE.UPCA, "038000356216", Color.Black, Color.White, 100, 25);
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Barcode (string, BarcodeLib.TYPE);
 If you decide to create an instance with parameters, the parameters are as follows: the string is the data to be encoded into the barcode, and BarcodeLib.TYPE is the symbology to encode the data with. If you do not choose to specify the data and type at the time the instance is created, you may specify them through the appropriate property later on (but before you encode).
 
 ```
-BarCodeLib.Barcode b = new BarCodeLib.Barcode(BarCodeLib.TYPE.UPCA, 
+BarcodeLib.Barcode b = new BarcodeLib.Barcode(BarcodeLib.TYPE.UPCA, 
           "038000356216", Color.Black, Color.White, 300, 150);
 ```
 ### Example ###
 ```
-BarCodeLib.Barcode b = new BarCodeLib.Barcode(BarCodeLib.TYPE.UPCA, 
-          "038000356216", Color.Black, Color.White, 300, 150);
-Image img = b.Encode();
+BarcodeLib.Barcode b = new BarcodeLib.Barcode();
+b.Alignment = BarcodeLib.AlignmentPositions.CENTER;
+Image img = b.Encode(BarcodeLib.TYPE.UPCA, "038000356216", Color.Black, Color.White, 100, 25);
 ```
 
 ### Copyright and license ###


### PR DESCRIPTION
Fixing the example to be copy-and-paste functional. (nice when deploying through nuget and trying out the library for the first time)