### PR TITLE
Added [assembly:AllowPartiallyTrustedCallers]

### DIFF
--- a/BarcodeLib/Properties/AssemblyInfo.cs
+++ b/BarcodeLib/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security;
+
+[assembly: AllowPartiallyTrustedCallers]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information


### PR DESCRIPTION
 This allows strongly typed assembly to be used in an SSRS report (MS ReportViewer)