### PR TITLE
Bump version for 1.3.1 release

### DIFF
--- a/BarcodeLib/Properties/AssemblyInfo.cs
+++ b/BarcodeLib/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Security;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]


### PR DESCRIPTION
Not sure how you push this to nuget.org, but because of null exception we can not use latest version (1.3) while fix already done 5 months ago but do not released to nuget.org. So I hope by increasing version maybe you have automated process to push it to nuget repo ar at least it will make you see that we waiting for new release.