### PR TITLE
Updating the Travis CI badge plus adding a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# barcodelib [![Build Status](https://www.travis-ci.org/barnhill/barcodelib.svg?branch=master)](https://travis-ci.org/barnhill/barcodelib)
-
-[Nuget package](https://www.nuget.org/packages/BarcodeLib)
+# barcodelib [![Build Status](https://www.travis-ci.org/barnhill/barcodelib.svg?branch=master)](https://travis-ci.org/barnhill/barcodelib) [![NuGet](https://img.shields.io/nuget/v/BarcodeLib.svg)](https://www.nuget.org/packages/BarcodeLib)
 
 ### Overview ###
  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# barcodelib ![Build Status](https://www.travis-ci.org/barnhill/barcodelib.svg?branch=master)
+# barcodelib [![Build Status](https://www.travis-ci.org/barnhill/barcodelib.svg?branch=master)](https://travis-ci.org/barnhill/barcodelib)
 
 [Nuget package](https://www.nuget.org/packages/BarcodeLib)
 


### PR DESCRIPTION
This is a simple cosmetic change on the Readme that:
- Redirects to the latest Travis CI build when the user clicks the badge
- Adds a new badge that shows the latest version on NuGet
