### PR TITLE
Correct "standard 2 of 5" digit codes

### DIFF
--- a/BarcodeStandard/Symbologies/Standard2of5.cs
+++ b/BarcodeStandard/Symbologies/Standard2of5.cs
@@ -8,7 +8,7 @@ namespace BarcodeLib.Symbologies
     /// </summary>
     class Standard2of5 : BarcodeCommon, IBarcode
     {
-        private readonly string[] S25_Code = { "11101010101110", "10111010101110", "11101110101010", "10101110101110", "11101011101010", "10111011101010", "10101011101110", "10101110111010", "11101010111010", "10111010111010" };
+        private readonly string[] S25_Code = { "10101110111010", "11101010101110", "10111010101110", "11101110101010", "10101110101110", "11101011101010", "10111011101010", "10101011101110", "11101010111010", "10111010111010" };
         private readonly TYPE Encoded_Type = TYPE.UNSPECIFIED;
 
         public Standard2of5(string input, TYPE EncodedType)


### PR DESCRIPTION
Testing _standard 2 of 5_ codes with barcode readers and also comparing with an online barcode generator, it is possible to verify that the codes for some digits were wrong.
The array containing the codes was in the following order: **[1,2,3,4,5,6,7,0,8,9]**.
To correct it, the only needed change was to bring the 8th code (number 0) to the begining of the array.