### PR TITLE
Moved CheckNumericOnly to ctor. Non-numeric data made CheckDigit thro…

### DIFF
--- a/BarcodeStandard/Symbologies/EAN8.cs
+++ b/BarcodeStandard/Symbologies/EAN8.cs
@@ -15,6 +15,9 @@ namespace BarcodeLib.Symbologies
         {
             Raw_Data = input;
 
+            //check numeric only
+            if (!CheckNumericOnly(Raw_Data)) Error("EEAN8-2: Numeric only.");
+
             CheckDigit();
         }
         /// <summary>
@@ -24,9 +27,6 @@ namespace BarcodeLib.Symbologies
         {
             //check length
             if (Raw_Data.Length != 8 && Raw_Data.Length != 7) Error("EEAN8-1: Invalid data length. (7 or 8 numbers only)");
-
-            //check numeric only
-            if (!CheckNumericOnly(Raw_Data)) Error("EEAN8-2: Numeric only.");
 
             //encode the data
             string result = "101";


### PR DESCRIPTION
…w a FormatException instead of a the more informative error "Numeric only".

This is a very small pull-req. My first on github actually. Need to test if I do it correct.

Added a test project to the solution (not included in the pull-req) with tests for EAN8. Feed it with garbage that should fail. But the test:

`Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "123X567"), "Should fail");`

did not throw an Exception. It threw a FormatException because the constructor allowed garbage into CheckDigit() which tried a Int32.Parse('X').

The test method for EAN8 looks like this so far:

```
[Test]
public void TestEAN8()
{
    var c = new BarcodeLib.Barcode();

    // Invalid lengths
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, ""), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "1"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "12"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "123"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "1234"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "12345"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "123456"), "Should fail");
    // 7 and 8 are valid lengths
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "123456789"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "1234567890"), "Should fail");

    // Valid lengths with invalid chars
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "123X567"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "X234567"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "123456X"), "Should fail");

    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "123X5678"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "X2345678"), "Should fail");
    Assert.Throws<Exception>(() => c.Encode(BarcodeLib.TYPE.EAN8, "1234567X"), "Should fail");
}
```