### PR TITLE
Remove unused solution configuration platforms

### DIFF
--- a/Barcode.sln
+++ b/Barcode.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27703.2018
@@ -12,38 +12,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BarcodeStandardExample", "B
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|.NET = Debug|.NET
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x86 = Debug|x86
-		Release|.NET = Release|.NET
 		Release|Any CPU = Release|Any CPU
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Debug|.NET.ActiveCfg = Debug|Any CPU
-		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Debug|.NET.Build.0 = Debug|Any CPU
 		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Debug|x86.Build.0 = Debug|Any CPU
-		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Release|.NET.ActiveCfg = Release|Any CPU
-		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Release|.NET.Build.0 = Release|Any CPU
 		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Release|x86.ActiveCfg = Release|Any CPU
-		{24B824A4-A4F1-4C31-A935-7EA11304B48B}.Release|x86.Build.0 = Release|Any CPU
-		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Debug|.NET.ActiveCfg = Debug|Any CPU
-		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Debug|.NET.Build.0 = Debug|Any CPU
 		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Debug|x86.Build.0 = Debug|Any CPU
-		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Release|.NET.ActiveCfg = Release|Any CPU
-		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Release|.NET.Build.0 = Release|Any CPU
 		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Release|Any CPU.Build.0 = Release|Any CPU
-		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Release|x86.ActiveCfg = Release|Any CPU
-		{411EC0AA-B1A0-4B77-AAAC-19AD20AA5678}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
AFAICT, the `x86` and `.NET` configurations are not used anywhere and don't do anything.

Removed them to simplify things, leaving `Any CPU` as the default.