### PR TITLE
Fix S2of5 checksum

### DIFF
--- a/BarcodeStandard/Symbologies/Standard2of5.cs
+++ b/BarcodeStandard/Symbologies/Standard2of5.cs
@@ -45,11 +45,13 @@ namespace BarcodeLib.Symbologies
             var even = true;
             for (var i = Raw_Data.Length - 1; i >= 0; --i)
             {
-                sum += Raw_Data[i] * (even ? 3 : 1);
+                //convert numeric in char format to integer and
+                //multiply by 3 or 1 based on if an even index from the end
+                sum += (Raw_Data[i] - '0') * (even ? 3 : 1);
                 even = !even;
             }
 
-            return sum % 10;
+            return (10 - sum % 10) % 10;
         }
 
         #region IBarcode Members


### PR DESCRIPTION
Same issue (https://github.com/barnhill/barcodelib/issues/97) with the Standard 2 of 5 checksum calculation