### PR TITLE
BarcodeStandardExample: Use implicit package references.

### DIFF
--- a/BarcodeStandardExample/BarcodeStandardExample.csproj
+++ b/BarcodeStandardExample/BarcodeStandardExample.csproj
@@ -36,9 +36,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing.Common, Version=4.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Drawing.Common.5.0.2\lib\net461\System.Drawing.Common.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -73,7 +70,6 @@
     <EmbeddedResource Include="TestApp.resx">
       <DependentUpon>TestApp.cs</DependentUpon>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/BarcodeStandardExample/packages.config
+++ b/BarcodeStandardExample/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.NETCore.Platforms" version="5.0.2" targetFramework="net462" />
-  <package id="NETStandard.Library" version="2.0.3" targetFramework="net462" />
-  <package id="System.Drawing.Common" version="5.0.2" targetFramework="net462" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
-</packages>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<Project>
+  <PropertyGroup>
+    <!-- Default new nuget package references to use PackageReference instead of old style packages.config -->
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
By setting RestoreProjectStyle to PackageReference in
Directory.Build.props, the entire solution is opted into using
PackageReference-style nuget restore, even if those packages do not
themselves have any direct PackageReference. This means that any
PackageReference to another project will automatically pull in the
nuget packages of that other project. For BarcodeStandardExample, this
means that it will automatically get the version of
System.Drawing.Common used by BarcodeStandard.

This may be a little sloppy, in that removing a PackageReference from
BarcodeStandard may break the build of BarcodeStandardExample. But I
think the simpler project files and reduced number of
manually-maintained PackageReference is worth it. And such a break
should be caught by CI.

This gets rid of packages.config usage. The packages.config style of
referencing nugets is old-style and the very fact that this puts
Reference and HintPath in the .csproj is unfortunate. So it is good to
move away from that.