### PR TITLE
Issue #139

### DIFF
--- a/Barcode.sln
+++ b/Barcode.sln
@@ -12,6 +12,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BarcodeStandardExample", "B
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BarcodeStandardTests", "BarcodeStandardTests\BarcodeStandardTests.csproj", "{C588CDB4-B0C9-4EC0-B790-F6F3ED443644}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionFiles", "SolutionFiles", "{1A2BC623-899C-437E-908D-AF41D8BC7C97}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/BarcodeStandard/CrystalReportsWrapper.cs
+++ b/BarcodeStandard/CrystalReportsWrapper.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using BarcodeStandard.Extensions;
+
+namespace BarcodeStandard
+{
+    public class CrystalReportsWrapper : IDisposable
+    {
+        public Image Image { get; set; }
+        public ImageFormat ImageFormat { get; set; }
+
+        /// <summary>
+        /// Gets a byte array representation of the encoded image. (Used for Crystal Reports)
+        /// </summary>
+        public byte[] Encoded_Image_Bytes => Image.EncodedImageBytes(ImageFormat);
+
+        public void Dispose()
+        {
+            Image?.Dispose();
+        }
+    }
+}

--- a/BarcodeStandard/Extensions/ImageExtensions.cs
+++ b/BarcodeStandard/Extensions/ImageExtensions.cs
@@ -1,0 +1,57 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using BarcodeLib;
+
+namespace BarcodeStandard.Extensions
+{
+    public static class ImageExtensions
+    {
+        public static byte[] EncodedImageBytes(this Image image, ImageFormat imageFormat)
+        {
+            if (image == null)
+                return null;
+
+            using (var ms = new MemoryStream())
+            {
+                image.Save(ms, imageFormat);
+                return ms.ToArray();
+            }
+        }
+        
+        
+        /// <summary>
+        /// Returns the size of the EncodedImage in real world coordinates (millimeters or inches).
+        /// </summary>
+        /// <param name="metric">Millimeters if true, otherwise Inches.</param>
+        /// <returns></returns>
+        public static Barcode.ImageSize GetSizeOfImage(this Image image, bool metric)
+        {
+            double Width = 0;
+            double Height = 0;
+            if (image != null && image.Width > 0 && image.Height > 0)
+            {
+                double MillimetersPerInch = 25.4;
+                using (Graphics g = Graphics.FromImage(image))
+                {
+                    Width = image.Width / g.DpiX;
+                    Height = image.Height / g.DpiY;
+
+                    if (metric)
+                    {
+                        Width *= MillimetersPerInch;
+                        Height *= MillimetersPerInch;
+                    }//if
+                }//using
+            }//if
+
+            return new Barcode.ImageSize(Width, Height, metric);
+        }
+
+        public static CrystalReportsWrapper ToCrystalReportsWrapper(this Image image, ImageFormat format) => new CrystalReportsWrapper()
+            {
+                Image = image,
+                ImageFormat = format
+            };
+    }
+}

--- a/BarcodeStandardExample/TestApp.cs
+++ b/BarcodeStandardExample/TestApp.cs
@@ -170,17 +170,18 @@ namespace BarcodeStandardExample
             sfd.AddExtension = true;
             if (sfd.ShowDialog() == DialogResult.OK)
             {
-                SaveTypes savetype = SaveTypes.UNSPECIFIED;
+                ImageFormat savetype = null;
                 switch (sfd.FilterIndex)
                 {
-                    case 1: /* BMP */  savetype = SaveTypes.BMP; break;
-                    case 2: /* GIF */  savetype = SaveTypes.GIF; break;
-                    case 3: /* JPG */  savetype = SaveTypes.JPG; break;
-                    case 4: /* PNG */  savetype = SaveTypes.PNG; break;
-                    case 5: /* TIFF */ savetype = SaveTypes.TIFF; break;
-                    default: break;
+                    case 1: /* BMP */  savetype = ImageFormat.Bmp; break;
+                    case 2: /* GIF */  savetype = ImageFormat.Gif; break;
+                    case 3: /* JPG */  savetype = ImageFormat.Jpeg; break;
+                    case 4: /* PNG */  savetype = ImageFormat.Png; break;
+                    case 5: /* TIFF */ savetype = ImageFormat.Tiff; break;
+                    default: savetype = b.ImageFormat; break;
                 }//switch
-                b.SaveImage(sfd.FileName, savetype);
+
+                barcode.BackgroundImage?.Save(sfd.FileName, savetype);
             }//if
         }//btnSave_Click
 

--- a/BarcodeStandardTests/ImageGenerationTest.cs
+++ b/BarcodeStandardTests/ImageGenerationTest.cs
@@ -1,0 +1,16 @@
+using BarcodeLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BarcodeStandardTests
+{
+    [TestClass]
+    public class ImageGenerationTest
+    {
+        [TestMethod]
+        public void CanUseGeneratedImage()
+        {
+            var image = Barcode.DoEncode(TYPE.Interleaved2of5, "0123456789");
+            var width = image.Width;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you decide to create an instance with parameters, the parameters are as follo
 
 ### Example ###
 ```csharp
-BarcodeLib.Barcode b = new BarcodeLib.Barcode();
+using BarcodeLib.Barcode b = new BarcodeLib.Barcode();
 Image img = b.Encode(BarcodeLib.TYPE.UPCA, "038000356216", Color.Black, Color.White, 290, 120);
 ```
 


### PR DESCRIPTION
Some breaking changes:
- `barcode.EncodedImage` becomes `barcode.Encode()`.
- `barcode.GetImageData` uses standard enum.
- `barcode.SaveImage` becomes `using var image = barcode.Encode(); image.Save`
- `barcode.GetSizeOfImage` becomes `using var image = barcode.Encode(); image.GetSizeOfImage`
- `barcode.Encoded_Image_Bytes` becomes `barcode.Encode().ToCrystalReportsWrapper(barcode.ImageFormat).Encoded_Image_Bytes`