### PR TITLE
Fix dynamic assembly memory leak, optimize Regex usage

### DIFF
--- a/BarcodeStandard/BarcodeCommon.cs
+++ b/BarcodeStandard/BarcodeCommon.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace BarcodeLib
 {
@@ -8,7 +7,6 @@ namespace BarcodeLib
     {
         protected string Raw_Data = "";
         protected List<string> _Errors = new List<string>();
-        private static readonly Regex _NumericOnlyRegex = new Regex(@"^\d+$", RegexOptions.Compiled);
 
         public string RawData
         {
@@ -28,7 +26,14 @@ namespace BarcodeLib
 
         internal static bool CheckNumericOnly(string data)
         {
-            return _NumericOnlyRegex.IsMatch(data);
+            for (var i = 0; i < data.Length; i++)
+            {
+                if (!char.IsDigit(data[i]))
+                {
+                    return false;
+                }
+            }
+            return data.Length > 0;
         }
     }//BarcodeVariables abstract class
 }//namespace

--- a/BarcodeStandard/BarcodeCommon.cs
+++ b/BarcodeStandard/BarcodeCommon.cs
@@ -8,6 +8,7 @@ namespace BarcodeLib
     {
         protected string Raw_Data = "";
         protected List<string> _Errors = new List<string>();
+        private static readonly Regex _NumericOnlyRegex = new Regex(@"^\d+$", RegexOptions.Compiled);
 
         public string RawData
         {
@@ -27,7 +28,7 @@ namespace BarcodeLib
 
         internal static bool CheckNumericOnly(string data)
         {
-            return Regex.IsMatch(data, @"^\d+$", RegexOptions.Compiled);
+            return _NumericOnlyRegex.IsMatch(data);
         }
     }//BarcodeVariables abstract class
 }//namespace

--- a/BarcodeStandard/BarcodeLib.cs
+++ b/BarcodeStandard/BarcodeLib.cs
@@ -1,16 +1,16 @@
+using BarcodeLib.Symbologies;
+using BarcodeStandard;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
-using System.IO;
 using System.Drawing.Imaging;
-using BarcodeLib.Symbologies;
-using BarcodeStandard;
-using System.Xml.Serialization;
+using System.IO;
 using System.Security;
-using System.Xml;
 using System.Text;
 using System.Text.Json;
+using System.Xml;
+using System.Xml.Serialization;
 
 /* 
  * ***************************************************
@@ -54,6 +54,7 @@ namespace BarcodeLib
         private LabelPositions _LabelPosition = LabelPositions.BOTTOMCENTER;
         private RotateFlipType _RotateFlipType = RotateFlipType.RotateNoneFlipNone;
         private bool _StandardizeLabel = true;
+        private static readonly XmlSerializer _SaveDataXmlSerializer = new XmlSerializer(typeof(SaveData));
         #endregion
 
         #region Constructors
@@ -669,7 +670,7 @@ namespace BarcodeLib
                                 // UPCA standardized label
                                 string defTxt = RawData;
                                 string labTxt = defTxt.Substring(0, 1) + "--" + defTxt.Substring(1, 6) + "--" + defTxt.Substring(7);
-                                
+
                                 Font labFont = new Font(this.LabelFont != null ? this.LabelFont.FontFamily.Name : "Arial", Labels.getFontsize(this, Width, Height, labTxt) * DotsPerPointAt96Dpi, FontStyle.Regular, GraphicsUnit.Pixel);
                                 if (this.LabelFont != null)
                                 {
@@ -1054,7 +1055,7 @@ namespace BarcodeLib
         #endregion
 
         #region XML Methods
-       
+
         private SaveData GetSaveData(Boolean includeImage = true)
         {
             SaveData saveData = new SaveData();
@@ -1101,10 +1102,9 @@ namespace BarcodeLib
                 {
                     using (SaveData xml = GetSaveData(includeImage))
                     {
-                        XmlSerializer writer = new XmlSerializer(typeof(SaveData));
                         using (Utf8StringWriter sw = new Utf8StringWriter())
                         {
-                            writer.Serialize(sw, xml);
+                            _SaveDataXmlSerializer.Serialize(sw, xml);
                             return sw.ToString();
                         }
                     }//using
@@ -1122,7 +1122,7 @@ namespace BarcodeLib
                 if (jsonStream is MemoryStream)
                 {
                     return JsonSerializer.Deserialize<SaveData>(((MemoryStream)jsonStream).ToArray());
-                } 
+                }
                 else
                 {
                     using (var memoryStream = new MemoryStream())
@@ -1131,17 +1131,16 @@ namespace BarcodeLib
                         return JsonSerializer.Deserialize<SaveData>(memoryStream.ToArray());
                     }
                 }
-                
+
             }
         }
         public static SaveData FromXML(Stream xmlStream)
         {
             try
             {
-                XmlSerializer serializer = new XmlSerializer(typeof(SaveData));
                 using (XmlReader reader = XmlReader.Create(xmlStream))
                 {
-                    return (SaveData)serializer.Deserialize(reader);
+                    return (SaveData)_SaveDataXmlSerializer.Deserialize(reader);
                 }
             }//try
             catch (Exception ex)

--- a/BarcodeStandard/BarcodeLib.cs
+++ b/BarcodeStandard/BarcodeLib.cs
@@ -1331,8 +1331,8 @@ namespace BarcodeLib
         {
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
-            // GC.SuppressFinalize(this);
+            // Call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it.	
+            GC.SuppressFinalize(this);
         }
         #endregion
 


### PR DESCRIPTION
Fixes #142, #144
- fix dynamic assembly memory leak by changing `XmlSerializer` to be static
- fix code analysis warning CA1816
- performance optimization for Regex usage (reduces cpu time, memory allocations)