### PR TITLE
Optimize `CheckNumericOnly`

### DIFF
--- a/BarcodeStandard/BarcodeCommon.cs
+++ b/BarcodeStandard/BarcodeCommon.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace BarcodeStandard
 {
@@ -17,15 +16,14 @@ namespace BarcodeStandard
 
         internal static bool CheckNumericOnly(string data)
         {
-            char c;
-            for (int i = 0; i < data.Length; i++)
+            foreach (var c in data)
             {
-                c = data[i];
                 if (c < '0' && c > '9') return false;
             }
+
             return true;
         }
-        
+
         internal static int GetAlignmentShiftAdjustment(Barcode barcode)
         {
             switch (barcode.Alignment)


### PR DESCRIPTION
Benchmark:

```

BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.3996/22H2/2022Update)
Intel Core i7-7820HQ CPU 2.90GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK 8.0.101
  [Host]               : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  .NET 6.0             : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2
  .NET 8.0             : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  .NET Framework 4.8.1 : .NET Framework 4.8.1 (4.8.9195.0), X64 RyuJIT VectorSize=256


```
| Method                  | Runtime              | Data          | Mean      | Error     | StdDev    | Ratio        | RatioSD | Allocated | Alloc Ratio |
|------------------------ |--------------------- |-------------- |----------:|----------:|----------:|-------------:|--------:|----------:|------------:|
| **For**     | **.NET 6.0**             | **1633782928459** | **13.825 ns** | **0.1971 ns** | **0.1747 ns** |     **baseline** |        **** |         **-** |          **NA** |
| Foreach | .NET 6.0             | 1633782928459 |  9.508 ns | 0.2147 ns | 0.2205 ns | 1.45x faster |   0.04x |         - |          NA |
|                         |                      |               |           |           |           |              |         |           |             |
| For     | .NET 8.0             | 1633782928459 |  8.053 ns | 0.1646 ns | 0.1459 ns |     baseline |         |         - |          NA |
| Foreach | .NET 8.0             | 1633782928459 |  6.731 ns | 0.1699 ns | 0.3149 ns | 1.19x faster |   0.07x |         - |          NA |
|                         |                      |               |           |           |           |              |         |           |             |
| For     | .NET Framework 4.8.1 | 1633782928459 | 12.746 ns | 0.2686 ns | 0.2381 ns |     baseline |         |         - |          NA |
| Foreach | .NET Framework 4.8.1 | 1633782928459 |  9.324 ns | 0.2230 ns | 0.3338 ns | 1.36x faster |   0.07x |         - |          NA |
|                         |                      |               |           |           |           |              |         |           |             |
| **For**     | **.NET 6.0**             | **NoNumericHere** | **13.085 ns** | **0.2023 ns** | **0.1793 ns** |     **baseline** |        **** |         **-** |          **NA** |
| Foreach | .NET 6.0             | NoNumericHere |  9.949 ns | 0.2733 ns | 0.7885 ns | 1.37x faster |   0.12x |         - |          NA |
|                         |                      |               |           |           |           |              |         |           |             |
| For     | .NET 8.0             | NoNumericHere |  8.901 ns | 0.2812 ns | 0.8157 ns |     baseline |         |         - |          NA |
| Foreach | .NET 8.0             | NoNumericHere |  7.729 ns | 0.2350 ns | 0.6856 ns | 1.16x faster |   0.13x |         - |          NA |
|                         |                      |               |           |           |           |              |         |           |             |
| For     | .NET Framework 4.8.1 | NoNumericHere | 12.945 ns | 0.1764 ns | 0.1563 ns |     baseline |         |         - |          NA |
| Foreach | .NET Framework 4.8.1 | NoNumericHere |  9.813 ns | 0.2633 ns | 0.7682 ns | 1.36x faster |   0.08x |         - |          NA |
|                         |                      |               |           |           |           |              |         |           |             |
| **For**     | **.NET 6.0**             | **Numeric56Text** | **14.553 ns** | **0.3292 ns** | **0.8900 ns** |     **baseline** |        **** |         **-** |          **NA** |
| Foreach | .NET 6.0             | Numeric56Text |  9.687 ns | 0.2278 ns | 0.2961 ns | 1.52x faster |   0.09x |         - |          NA |
|                         |                      |               |           |           |           |              |         |           |             |
| For     | .NET 8.0             | Numeric56Text |  8.759 ns | 0.2091 ns | 0.2719 ns |     baseline |         |         - |          NA |
| Foreach | .NET 8.0             | Numeric56Text |  7.009 ns | 0.1694 ns | 0.1883 ns | 1.25x faster |   0.05x |         - |          NA |
|                         |                      |               |           |           |           |              |         |           |             |
| For     | .NET Framework 4.8.1 | Numeric56Text | 13.821 ns | 0.3142 ns | 0.5249 ns |     baseline |         |         - |          NA |
| Foreach | .NET Framework 4.8.1 | Numeric56Text |  9.750 ns | 0.2284 ns | 0.4346 ns | 1.42x faster |   0.09x |         - |          NA |


<details>

<summary>Code</summary>

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Jobs;

namespace BenchmarkTemplate;

[MemoryDiagnoser]
[Config(typeof(StyleConfig))]
[HideColumns("Job")]
[SimpleJob(RuntimeMoniker.Net481)]
[SimpleJob(RuntimeMoniker.Net60)]
[SimpleJob(RuntimeMoniker.Net80)]
public class CheckNumericOnlyBenchmarks
{
    [Params("Numeric56Text", "NoNumericHere", "1633782928459")]
    public string Data;

    [Benchmark(Baseline = true)]
    public bool For()
    {
        char c;
        for (int i = 0; i < Data.Length; i++)
        {
            c = Data[i];
            if (c < '0' && c > '9')
            {
                return false;
            }
        }

        return true;
    }

    [Benchmark]
    public bool Foreach()
    {
        foreach (var c in Data)
        {
            if (c < '0' && c > '9')
            {
                return false;
            }
        }

        return true;
    }
}
```

</details>