### PR TITLE
JAN-13 barcode doesn't automatically calculate checksum when not provided

### DIFF
--- a/BarcodeStandard/BarcodeLib.cs
+++ b/BarcodeStandard/BarcodeLib.cs
@@ -555,6 +555,7 @@ namespace BarcodeStandard
 
                         break;
                     }//case
+                case Type.Jan13:
                 case Type.Ean13:
                     {
                         // Automatically calculate Width if applicable.

--- a/BarcodeStandard/Symbologies/JAN13.cs
+++ b/BarcodeStandard/Symbologies/JAN13.cs
@@ -6,12 +6,16 @@ namespace BarcodeLib.Symbologies
     ///  JAN-13 encoding
     ///  Written by: Brad Barnhill
     /// </summary>
-    class JAN13 : BarcodeCommon, IBarcode
+    internal class JAN13 : BarcodeCommon, IBarcode
     {
+        private readonly EAN13 _ean13;
+
         public JAN13(string input)
         {
-            RawData = input;
+            _ean13 = new EAN13(input);
+            RawData = _ean13.RawData;
         }
+
         /// <summary>
         /// Encode the raw data using the JAN-13 algorithm.
         /// </summary>
@@ -21,14 +25,13 @@ namespace BarcodeLib.Symbologies
             if (!CheckNumericOnly(RawData))
                 Error("EJAN13-2: Numeric Data Only");
 
-            EAN13 ean13 = new EAN13(RawData);
-            return ean13.Encoded_Value;
+            return _ean13.Encoded_Value;
         }//Encode_JAN13
 
         #region IBarcode Members
 
         public string Encoded_Value => Encode_JAN13();
 
-        #endregion
+        #endregion IBarcode Members
     }
 }

--- a/BarcodeStandardTests/Symbologies/Ean13Tests.cs
+++ b/BarcodeStandardTests/Symbologies/Ean13Tests.cs
@@ -20,5 +20,16 @@ namespace BarcodeStandardTests.Symbologies
             _barcode.Encode(data);
             Assert.AreEqual(expected, _barcode.EncodedValue, $"{_barcode.EncodedType}");
         }
+
+        [DataTestMethod]
+        [DataRow("498000356216", "4980003562162")]
+        [DataRow("4980003562162", "4980003562162")]
+        [DataRow("493123123123", "4931231231238")]
+        public void CalculateChecksum(string data, string expected)
+        {
+            _barcode.Encode(data);
+
+            Assert.AreEqual(expected, _barcode.RawData);
+        }
     }
 }

--- a/BarcodeStandardTests/Symbologies/Jan13Tests.cs
+++ b/BarcodeStandardTests/Symbologies/Jan13Tests.cs
@@ -15,10 +15,22 @@ namespace BarcodeStandardTests.Symbologies
         [DataRow("498000356216", "10100010110001001000110100011010100111010000101010100111010100001101100110011010100001101100101")]
         [DataRow("493456789012", "10100010110100001010001101100010000101001000101010100100011101001110010110011011011001011100101")]
         [DataRow("492794729478", "10100010110011011011101100010110011101001000101010110110011101001011100100010010010001110010101")]
+        [DataRow("493123123123", "10100010110100001001100100100110100001011001101010110110010000101100110110110010000101001000101")]
         public void EncodeBarcode(string data, string expected)
         {
             _barcode.Encode(data);
             Assert.AreEqual(expected, _barcode.EncodedValue, $"{_barcode.EncodedType}");
+        }
+
+        [DataTestMethod]
+        [DataRow("498000356216", "4980003562162")]
+        [DataRow("4980003562162", "4980003562162")]
+        [DataRow("493123123123", "4931231231238")]
+        public void CalculateChecksum(string data, string expected)
+        {
+            _barcode.Encode(data);
+
+            Assert.AreEqual(expected, _barcode.RawData);
         }
     }
 }


### PR DESCRIPTION
JAN-13 barcode doesn't automatically calculate checksum when not provided. This differs from the EAN-13 behaviour which calculates it correctly.

The provided unit tests reproduces that case. 