### PR TITLE
Support for rendering top bar/bearer bars

### DIFF
--- a/BarcodeStandard/BarcodeCommon.cs
+++ b/BarcodeStandard/BarcodeCommon.cs
@@ -24,17 +24,31 @@ namespace BarcodeStandard
             return true;
         }
 
-        internal static int GetAlignmentShiftAdjustment(Barcode barcode)
+        internal static int GetQuietZoneAdjustment(Barcode barcode)
         {
+            if (barcode.IncludeLabel && barcode.GuardBarsMode == GuardBarsMode.EnabledFirstCharOnQuietZone)
+            {
+                return Utils.GetFontWidth("0", barcode.LabelFont) * 2;
+            }
+
+            return 0;
+        }
+
+        internal static int GetAlignmentShiftAdjustment(Barcode barcode)
+        { 
+            var quietZoneAdjustment = BarcodeCommon.GetQuietZoneAdjustment(barcode);
+
             switch (barcode.Alignment)
             {
                 case AlignmentPositions.Left:
-                    return 0;
+                    return quietZoneAdjustment;
+
                 case AlignmentPositions.Right:
-                    return (barcode.Width % barcode.EncodedValue.Length);
+                    return ((barcode.Width - quietZoneAdjustment * 2) % barcode.EncodedValue.Length) + quietZoneAdjustment;
+
                 case AlignmentPositions.Center:
                 default:
-                    return (barcode.Width % barcode.EncodedValue.Length) / 2;
+                    return ((barcode.Width - quietZoneAdjustment * 2) % barcode.EncodedValue.Length) / 2 + quietZoneAdjustment;
             }//switch
         }
     }//BarcodeVariables abstract class

--- a/BarcodeStandard/BarcodeLib.cs
+++ b/BarcodeStandard/BarcodeLib.cs
@@ -10,8 +10,9 @@ using System.Xml.Serialization;
 using BarcodeLib;
 using BarcodeLib.Symbologies;
 using SkiaSharp;
+using static System.Net.Mime.MediaTypeNames;
 
-/* 
+/*
  * ***************************************************
  *                 Barcode Library                   *
  *                                                   *
@@ -23,16 +24,25 @@ using SkiaSharp;
  *  barcode images from a string of data.            *
  * ***************************************************
  */
+
 namespace BarcodeStandard
 {
     #region Enums
+
     public enum Type
     { Unspecified, UpcA, UpcE, UpcSupplemental2Digit, UpcSupplemental5Digit, Ean13, Ean8, Interleaved2Of5, Interleaved2Of5Mod10, Standard2Of5, Standard2Of5Mod10, Industrial2Of5, Industrial2Of5Mod10, Code39, Code39Extended, Code39Mod43, Codabar, PostNet, Bookland, Isbn, Jan13, MsiMod10, Msi2Mod10, MsiMod11, MsiMod11Mod10, ModifiedPlessey, Code11, Usd8, Ucc12, Ucc13, Logmars, Code128, Code128A, Code128B, Code128C, Itf14, Code93, Telepen, Fim, Pharmacode }
+
     public enum SaveTypes
     { Jpg, Png, Webp, Unspecified }
+
     public enum AlignmentPositions
     { Center, Left, Right }
-    #endregion
+
+    public enum GuardBarsMode
+    { Enabled, EnabledFirstCharOnQuietZone, Disabled }
+
+    #endregion Enums
+
     /// <summary>
     /// Generates a barcode image of a specified symbology from a string of data.
     /// </summary>
@@ -40,11 +50,14 @@ namespace BarcodeStandard
     public class Barcode : IDisposable
     {
         #region Variables
+
         private IBarcode _iBarcode = new Blank();
         private static readonly XmlSerializer SaveDataXmlSerializer = new XmlSerializer(typeof(SaveData));
-        #endregion
+
+        #endregion Variables
 
         #region Constructors
+
         /// <summary>
         /// Default constructor.  Does not populate the raw data.  MUST be done via the RawData property before encoding.
         /// </summary>
@@ -52,6 +65,7 @@ namespace BarcodeStandard
         {
             //constructor
         }//Barcode
+
         /// <summary>
         /// Constructor. Populates the raw data. No whitespace will be added before or after the barcode.
         /// </summary>
@@ -61,19 +75,23 @@ namespace BarcodeStandard
             //constructor
             RawData = data;
         }//Barcode
+
         public Barcode(string data, Type iType)
         {
             RawData = data;
             EncodedType = iType;
             GenerateBarcode();
         }
-        #endregion
+
+        #endregion Constructors
 
         #region Properties
+
         /// <summary>
         /// Gets or sets the raw data to encode.
         /// </summary>
         public string RawData { get; set; } = ""; //RawData
+
         /// <summary>
         /// Gets the encoded value.
         /// </summary>
@@ -88,6 +106,7 @@ namespace BarcodeStandard
         /// Gets or sets the Encoded Type (ex. UPC-A, EAN-13 ... etc)
         /// </summary>
         public Type EncodedType { set; get; } = Type.Unspecified; //EncodedType
+
         /// <summary>
         /// Gets the Image of the generated barcode.
         /// </summary>
@@ -97,14 +116,17 @@ namespace BarcodeStandard
         /// Gets or sets the color of the bars. (Default is black)
         /// </summary>
         public SKColorF ForeColor { get; set; } = SKColors.Black; //ForeColor
+
         /// <summary>
         /// Gets or sets the background color. (Default is white)
         /// </summary>
         public SKColorF BackColor { get; set; } = SKColors.White; //BackColor
+
         /// <summary>
         /// Gets or sets the label font. (Default is Microsoft Sans Serif, 10pt, Bold)
         /// </summary>
         public SKFont LabelFont { get; set; } = new SKFont(SKTypeface.FromFamilyName("Arial", SKFontStyle.Bold), 28); //LabelFont
+
         /// <summary>
         /// Gets or sets the width of the image to be drawn. (Default is 300 pixels)
         /// </summary>
@@ -119,6 +141,7 @@ namespace BarcodeStandard
         ///   If non-null, sets the width of a bar. <see cref="Width"/> is ignored and calculated automatically.
         /// </summary>
         public int? BarWidth { get; set; }
+
         /// <summary>
         ///   If non-null, <see cref="Height"/> is ignored and set to <see cref="Width"/> divided by this value rounded down.
         /// </summary>
@@ -131,6 +154,7 @@ namespace BarcodeStandard
         ///   calculated. So it is safe to use in conjunction with <see cref="BarWidth"/>.
         /// </para></remarks>
         public double? AspectRatio { get; set; }
+
         /// <summary>
         /// Gets or sets whether a label should be drawn below the image. (Default is false)
         /// </summary>
@@ -142,6 +166,13 @@ namespace BarcodeStandard
         public String AlternateLabel { get; set; }
 
         /// <summary>
+        /// Mode when rendering guard bars for barcodes that support them (EAN-8/EAN-13/UPC-A/UPC-E)
+        /// 
+        /// Functionality not implemented for codes other than EAN-13
+        /// </summary>
+        public GuardBarsMode GuardBarsMode { get; set; }
+
+        /// <summary>
         /// Gets or sets the amount of time in milliseconds that it took to encode and draw the barcode.
         /// </summary>
         public double EncodingTime
@@ -149,6 +180,7 @@ namespace BarcodeStandard
             get;
             set;
         }
+
         /// <summary>
         /// Gets or sets the image format to use when encoding and returning images. (Jpeg is default)
         /// </summary>
@@ -167,6 +199,7 @@ namespace BarcodeStandard
             get;
             set;
         }//Alignment
+
         /// <summary>
         /// Gets a byte array representation of the encoded image. (Used for Crystal Reports)
         /// </summary>
@@ -184,6 +217,7 @@ namespace BarcodeStandard
                 }//using
             }
         }
+
         /// <summary>
         /// Gets the assembly version information.
         /// </summary>
@@ -193,9 +227,11 @@ namespace BarcodeStandard
         /// Disables EAN13 invalid country code exception.
         /// </summary>
         public bool DisableEan13CountryException { get; set; } = false;
-        #endregion
+
+        #endregion Properties
 
         #region General Encode
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -242,6 +278,7 @@ namespace BarcodeStandard
             ForeColor = foreColor;
             return Encode(iType, stringToEncode);
         }//(Image)Encode(Type, string, Color, Color)
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -253,6 +290,7 @@ namespace BarcodeStandard
             RawData = stringToEncode;
             return Encode(iType);
         }//(Image)Encode(TYPE, string)
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -262,11 +300,13 @@ namespace BarcodeStandard
             EncodedType = iType;
             return Encode();
         }//Encode()
+
         public SKImage Encode(string stringToEncode)
         {
             RawData = stringToEncode;
             return Encode();
         }//(Image)Encode(TYPE, string)
+
         /// <summary>
         /// Encodes the raw data into a barcode image.
         /// </summary>
@@ -282,7 +322,7 @@ namespace BarcodeStandard
             EncodedImage = SKImage.FromBitmap(Generate_Image());
 
             EncodingTime = (DateTime.Now - dtStartTime).TotalMilliseconds;
-            
+
             return EncodedImage;
         }//Encode
 
@@ -290,7 +330,7 @@ namespace BarcodeStandard
         /// Encodes the raw data into binary form representing bars and spaces.
         /// </summary>
         /// <returns>
-        /// Returns a string containing the binary value of the barcode. 
+        /// Returns a string containing the binary value of the barcode.
         /// This also sets the internal values used within the class.
         /// </returns>
         /// <param name="rawData" >Optional raw_data parameter to for quick barcode generation</param>
@@ -310,53 +350,65 @@ namespace BarcodeStandard
 
             EncodedValue = "";
             CountryAssigningManufacturerCode = "N/A";
-            
+
             switch (EncodedType)
             {
                 case Type.Ucc12:
                 case Type.UpcA: //Encode_UPCA();
                     _iBarcode = new UPCA(RawData);
                     break;
+
                 case Type.Ucc13:
                 case Type.Ean13: //Encode_EAN13();
                     _iBarcode = new EAN13(RawData, DisableEan13CountryException);
                     break;
+
                 case Type.Interleaved2Of5Mod10:
                 case Type.Interleaved2Of5: //Encode_Interleaved2of5();
                     _iBarcode = new Interleaved2of5(RawData, EncodedType);
                     break;
+
                 case Type.Industrial2Of5Mod10:
                 case Type.Industrial2Of5:
                 case Type.Standard2Of5Mod10:
                 case Type.Standard2Of5: //Encode_Standard2of5();
                     _iBarcode = new Standard2of5(RawData, EncodedType);
                     break;
+
                 case Type.Logmars:
                 case Type.Code39: //Encode_Code39();
                     _iBarcode = new Code39(RawData);
                     break;
+
                 case Type.Code39Extended:
                     _iBarcode = new Code39(RawData, true);
                     break;
+
                 case Type.Code39Mod43:
                     _iBarcode = new Code39(RawData, false, true);
                     break;
+
                 case Type.Codabar: //Encode_Codabar();
                     _iBarcode = new Codabar(RawData);
                     break;
+
                 case Type.PostNet: //Encode_PostNet();
                     _iBarcode = new Postnet(RawData);
                     break;
+
                 case Type.Isbn:
                 case Type.Bookland: //Encode_ISBN_Bookland();
                     _iBarcode = new ISBN(RawData);
                     break;
+
                 case Type.Jan13: //Encode_JAN13();
                     _iBarcode = new JAN13(RawData);
                     break;
+
                 case Type.UpcSupplemental2Digit: //Encode_UPCSupplemental_2();
                     _iBarcode = new UPCSupplement2(RawData);
                     break;
+
                 case Type.MsiMod10:
                 case Type.Msi2Mod10:
                 case Type.MsiMod11:
@@ -364,43 +416,56 @@ namespace BarcodeStandard
                 case Type.ModifiedPlessey: //Encode_MSI();
                     _iBarcode = new MSI(RawData, EncodedType);
                     break;
+
                 case Type.UpcSupplemental5Digit: //Encode_UPCSupplemental_5();
                     _iBarcode = new UPCSupplement5(RawData);
                     break;
+
                 case Type.UpcE: //Encode_UPCE();
                     _iBarcode = new UPCE(RawData);
                     break;
+
                 case Type.Ean8: //Encode_EAN8();
                     _iBarcode = new EAN8(RawData);
                     break;
+
                 case Type.Usd8:
                 case Type.Code11: //Encode_Code11();
                     _iBarcode = new Code11(RawData);
                     break;
+
                 case Type.Code128: //Encode_Code128();
                     _iBarcode = new Code128(RawData);
                     break;
+
                 case Type.Code128A:
                     _iBarcode = new Code128(RawData, Code128.TYPES.A);
                     break;
+
                 case Type.Code128B:
                     _iBarcode = new Code128(RawData, Code128.TYPES.B);
                     break;
+
                 case Type.Code128C:
                     _iBarcode = new Code128(RawData, Code128.TYPES.C);
                     break;
+
                 case Type.Itf14:
                     _iBarcode = new ITF14(RawData);
                     break;
+
                 case Type.Code93:
                     _iBarcode = new Code93(RawData);
                     break;
+
                 case Type.Telepen:
                     _iBarcode = new Telepen(RawData);
                     break;
+
                 case Type.Fim:
                     _iBarcode = new FIM(RawData);
                     break;
+
                 case Type.Pharmacode:
                     _iBarcode = new Pharmacode(RawData);
                     break;
@@ -410,9 +475,11 @@ namespace BarcodeStandard
 
             return _iBarcode.Encoded_Value;
         }
-        #endregion
+
+        #endregion General Encode
 
         #region Image Functions
+
         /// <summary>
         /// Gets a bitmap representation of the encoded data.
         /// </summary>
@@ -447,7 +514,7 @@ namespace BarcodeStandard
                         var ilHeight = Height;
                         if (IncludeLabel)
                         {
-                            ilHeight -= Utils.GetFontHeight(RawData, LabelFont);  
+                            ilHeight -= Utils.GetFontHeight(RawData, LabelFont);
                         }
 
                         bitmap = new SKBitmap(Width, Height);
@@ -462,7 +529,7 @@ namespace BarcodeStandard
 
                         //draw image
                         var pos = 0;
-                        
+
                         var canvas = new SKCanvas(bitmap);
 
                         //fill background
@@ -497,7 +564,7 @@ namespace BarcodeStandard
 
                         if (IncludeLabel)
                             Labels.Label_ITF14(this, bitmap);
-                        
+
                         break;
                     }//case
                 case Type.UpcA:
@@ -528,7 +595,7 @@ namespace BarcodeStandard
                         {
                             //clears the image and colors the entire background
                             canvas.Clear(BackColor);
-                            
+
                             var barwidth = iBarWidth;
                             //lines are fBarWidth wide so draw the appropriate color line vertically
 
@@ -547,7 +614,7 @@ namespace BarcodeStandard
                                 }//while
                             }//using
                         }
-                       
+
                         if (IncludeLabel)
                         {
                             Labels.Label_UPCA(this, bitmap);
@@ -563,8 +630,15 @@ namespace BarcodeStandard
                         // Automatically calculate Height if applicable.
                         Height = (int?)(Width / AspectRatio) ?? Height;
 
+                        var ilWidth = Width;
                         var ilHeight = Height;
                         var topLabelAdjustment = 0;
+
+                        // If first char is printed outside of the code we need to shift the image right and reduce it's width to compensate
+                        var quietZoneAdjustment = BarcodeCommon.GetQuietZoneAdjustment(this);
+
+                        // We reduce the image size by quite zone form both ends
+                        ilWidth -= quietZoneAdjustment * 2;
 
                         //set alignment
                         var shiftAdjustment = BarcodeCommon.GetAlignmentShiftAdjustment(this);
@@ -572,7 +646,7 @@ namespace BarcodeStandard
                         if (IncludeLabel)
                         {
                             // Shift drawing down if top label.
-                            if (AlternateLabel != null)
+                            if (AlternateLabel != null)// || GuardBarsMode == GuardBarsMode.Disabled)
                             {
                                 topLabelAdjustment = Utils.GetFontHeight(RawData, LabelFont);
                                 ilHeight -= Utils.GetFontHeight(RawData, LabelFont);
@@ -580,7 +654,7 @@ namespace BarcodeStandard
                         }
 
                         bitmap = new SKBitmap(Width, Height);
-                        var iBarWidth = Width / EncodedValue.Length;
+                        var iBarWidth = ilWidth / EncodedValue.Length;
                         if (iBarWidth <= 0)
                             throw new Exception("EGENERATE_IMAGE-2: Image size specified not large enough to draw image. (Bar size determined to be less than 1 pixel)");
 
@@ -611,7 +685,14 @@ namespace BarcodeStandard
 
                         if (IncludeLabel)
                         {
-                            Labels.Label_EAN13(this, bitmap);
+                            if (GuardBarsMode != GuardBarsMode.Disabled)
+                            {
+                                Labels.Label_EAN13(this, bitmap, iBarWidth);
+                            }
+                            else
+                            {
+                                Labels.Label_Generic(this, bitmap);
+                            }
                         }
 
                         break;
@@ -649,7 +730,7 @@ namespace BarcodeStandard
                             canvas.Clear((SKColor)BackColor);
 
                             var barWidth = iBarWidth / iBarWidthModifier;
-                            
+
                             //lines are fBarWidth wide so draw the appropriate color line vertically
                             using (var backPaint = new SKPaint())
                             {
@@ -667,7 +748,7 @@ namespace BarcodeStandard
                                             var y = 0f;
                                             if (EncodedValue[pos] == '0')
                                                 y = ilHeight - ilHeight * 0.4f;
-                                            
+
                                             canvas.DrawLine(new SKPoint(pos * iBarWidth + shiftAdjustment + halfBarWidth, ilHeight), new SKPoint(pos * iBarWidth + shiftAdjustment + halfBarWidth, y), forePaint);
                                         }//if
                                         else
@@ -682,7 +763,7 @@ namespace BarcodeStandard
                         }//using
                         if (IncludeLabel)
                         {
-                           Labels.Label_Generic(this, bitmap);
+                            Labels.Label_Generic(this, bitmap);
                         }//if
 
                         break;
@@ -709,7 +790,7 @@ namespace BarcodeStandard
             {
                 if (EncodedImage != null)
                 {
-                    //Save the image to a memory stream so that we can get a byte array!      
+                    //Save the image to a memory stream so that we can get a byte array!
                     using (var ms = new MemoryStream())
                     {
                         SaveImage(ms, savetype);
@@ -722,9 +803,10 @@ namespace BarcodeStandard
             catch (Exception ex)
             {
                 throw new Exception("EGETIMAGEDATA-1: Could not retrieve image data. " + ex.Message);
-            }//catch  
+            }//catch
             return imageData;
         }
+
         /// <summary>
         /// Saves an encoded image to a specified file and type.
         /// </summary>
@@ -747,6 +829,7 @@ namespace BarcodeStandard
                 throw new Exception("ESAVEIMAGE-1: Could not save image.\n\n=======================\n\n" + ex.Message);
             }//catch
         }//SaveImage(string, SaveTypes)
+
         /// <summary>
         /// Saves an encoded image to a specified stream.
         /// </summary>
@@ -775,8 +858,8 @@ namespace BarcodeStandard
                 default: return ImageFormat;
             }//switch
         }
-        
-        #endregion
+
+        #endregion Image Functions
 
         #region XML Methods
 
@@ -806,6 +889,7 @@ namespace BarcodeStandard
             }//using
             return saveData;
         }
+
         public string ToJson(Boolean includeImage = true)
         {
             var bytes = JsonSerializer.SerializeToUtf8Bytes(GetSaveData(includeImage));
@@ -835,6 +919,7 @@ namespace BarcodeStandard
                 }//catch
             }//else
         }
+
         public static SaveData FromJson(Stream jsonStream)
         {
             using (jsonStream)
@@ -851,6 +936,7 @@ namespace BarcodeStandard
                 }
             }
         }
+
         public static SaveData FromXml(Stream xmlStream)
         {
             try
@@ -865,6 +951,7 @@ namespace BarcodeStandard
                 throw new Exception("EGETIMAGEFROMXML-1: " + ex.Message);
             }//catch
         }
+
         public static SKImage GetImageFromSaveData(SaveData saveData)
         {
             try
@@ -885,9 +972,11 @@ namespace BarcodeStandard
         {
             public override Encoding Encoding => new UTF8Encoding(false);
         }
-        #endregion
+
+        #endregion XML Methods
 
         #region Static Encode Methods
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -901,6 +990,7 @@ namespace BarcodeStandard
                 return b.Encode(iType, data);
             }//using
         }
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -917,6 +1007,7 @@ namespace BarcodeStandard
                 return i;
             }//using
         }
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -932,6 +1023,7 @@ namespace BarcodeStandard
                 return b.Encode(iType, data);
             }//using
         }
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -949,6 +1041,7 @@ namespace BarcodeStandard
                 return b.Encode(iType, data, width, height);
             }//using
         }
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -966,6 +1059,7 @@ namespace BarcodeStandard
                 return b.Encode(iType, data, new SKColor(drawColor.R, drawColor.G, drawColor.B, drawColor.A), new SKColor(backColor.R, backColor.G, backColor.B, backColor.A));
             }//using
         }
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -985,6 +1079,7 @@ namespace BarcodeStandard
                 return b.Encode(iType, data, new SKColor(drawColor.R, drawColor.G, drawColor.B, drawColor.A), new SKColor(backColor.R, backColor.G, backColor.B, backColor.A), width, height);
             }//using
         }
+
         /// <summary>
         /// Encodes the raw data into binary form representing bars and spaces.  Also generates an Image of the barcode.
         /// </summary>
@@ -1009,6 +1104,7 @@ namespace BarcodeStandard
         }
 
         #region IDisposable Support
+
         private bool _disposedValue; // To detect redundant calls
 
         protected virtual void Dispose(bool disposing)
@@ -1033,22 +1129,24 @@ namespace BarcodeStandard
             EncodedValue = null;
             CountryAssigningManufacturerCode = null;
         }
-        
-         ~Barcode() {
-           // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-           Dispose(false);
-         }
+
+        ~Barcode()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
 
         // This code added to correctly implement the disposable pattern.
         void IDisposable.Dispose()
         {
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
-            // Call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it.	
+            // Call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it.
             GC.SuppressFinalize(this);
         }
-        #endregion
 
-        #endregion
+        #endregion IDisposable Support
+
+        #endregion Static Encode Methods
     }//Barcode Class
 }//Barcode namespace

--- a/BarcodeStandard/BarcodeLib.cs
+++ b/BarcodeStandard/BarcodeLib.cs
@@ -167,7 +167,7 @@ namespace BarcodeStandard
 
         /// <summary>
         /// Mode when rendering guard bars for barcodes that support them (EAN-8/EAN-13/UPC-A/UPC-E)
-        /// 
+        ///
         /// Functionality not implemented for codes other than EAN-13
         /// </summary>
         public GuardBarsMode GuardBarsMode { get; set; }
@@ -227,6 +227,15 @@ namespace BarcodeStandard
         /// Disables EAN13 invalid country code exception.
         /// </summary>
         public bool DisableEan13CountryException { get; set; } = false;
+
+        /// <summary>
+        /// Enable rendering of top bar when rendering code.
+        ///
+        /// Top bar is typically used when printing codes on thermal printers
+        /// to detect damaged print head dots. Damage dots would create missing bars that
+        /// could cause the barcode to be invalid/unreadable.
+        /// </summary>
+        public bool IncludeTopBar { get; set; }
 
         #endregion Properties
 
@@ -563,7 +572,9 @@ namespace BarcodeStandard
                         }//using
 
                         if (IncludeLabel)
+                        {
                             Labels.Label_ITF14(this, bitmap);
+                        }
 
                         break;
                     }//case
@@ -590,6 +601,7 @@ namespace BarcodeStandard
                         //draw image
                         var pos = 0;
                         var halfBarWidth = (int)(iBarWidth * 0.5);
+                        var totalBarcodeWidth = EncodedValue.Length * iBarWidth;
 
                         using (var canvas = new SKCanvas(bitmap))
                         {
@@ -617,7 +629,19 @@ namespace BarcodeStandard
 
                         if (IncludeLabel)
                         {
-                            Labels.Label_UPCA(this, bitmap);
+                            if (GuardBarsMode != GuardBarsMode.Disabled)
+                            {
+                                Labels.Label_UPCA(this, bitmap);
+                            }
+                            else
+                            {
+                                Labels.Label_Generic(this, bitmap, totalBarcodeWidth);
+                            }
+                        }
+
+                        if (IncludeTopBar)
+                        {
+                            Labels.TopBar(this, bitmap, shiftAdjustment, totalBarcodeWidth, iBarWidth);
                         }
 
                         break;
@@ -696,6 +720,11 @@ namespace BarcodeStandard
                             }
                         }
 
+                        if (IncludeTopBar)
+                        {
+                            Labels.TopBar(this, bitmap, shiftAdjustment, totalBarcodeWidth, iBarWidth);
+                        }
+
                         break;
                     }//case
                 default:
@@ -767,6 +796,11 @@ namespace BarcodeStandard
                         {
                             Labels.Label_Generic(this, bitmap, totalBarcodeWidth);
                         }//if
+
+                        if (IncludeTopBar)
+                        {
+                            Labels.TopBar(this, bitmap, shiftAdjustment, totalBarcodeWidth, iBarWidth);
+                        }
 
                         break;
                     }//switch

--- a/BarcodeStandard/BarcodeLib.cs
+++ b/BarcodeStandard/BarcodeLib.cs
@@ -661,6 +661,7 @@ namespace BarcodeStandard
                         //draw image
                         var pos = 0;
                         var halfBarWidth = (int)(iBarWidth * 0.5);
+                        var totalBarcodeWidth = EncodedValue.Length * iBarWidth;
 
                         using (var canvas = new SKCanvas(bitmap))
                         {
@@ -691,7 +692,7 @@ namespace BarcodeStandard
                             }
                             else
                             {
-                                Labels.Label_Generic(this, bitmap);
+                                Labels.Label_Generic(this, bitmap, totalBarcodeWidth);
                             }
                         }
 
@@ -724,12 +725,13 @@ namespace BarcodeStandard
                         var pos = 0;
                         var halfBarWidth = (int)Math.Round(iBarWidth * 0.5);
 
+                        var barWidth = iBarWidth / iBarWidthModifier;
+                        var totalBarcodeWidth = EncodedValue.Length * barWidth;
+
                         using (var canvas = new SKCanvas(bitmap))
                         {
                             //clears the image and colors the entire background
                             canvas.Clear((SKColor)BackColor);
-
-                            var barWidth = iBarWidth / iBarWidthModifier;
 
                             //lines are fBarWidth wide so draw the appropriate color line vertically
                             using (var backPaint = new SKPaint())
@@ -763,7 +765,7 @@ namespace BarcodeStandard
                         }//using
                         if (IncludeLabel)
                         {
-                            Labels.Label_Generic(this, bitmap);
+                            Labels.Label_Generic(this, bitmap, totalBarcodeWidth);
                         }//if
 
                         break;

--- a/BarcodeStandard/BarcodeLib.cs
+++ b/BarcodeStandard/BarcodeLib.cs
@@ -41,6 +41,9 @@ namespace BarcodeStandard
     public enum GuardBarsMode
     { Enabled, EnabledFirstCharOnQuietZone, Disabled }
 
+    public enum BearerBarsMode
+    { Frame, BearerBars, Disabled }
+
     #endregion Enums
 
     /// <summary>
@@ -171,6 +174,13 @@ namespace BarcodeStandard
         /// Functionality not implemented for codes other than EAN-13
         /// </summary>
         public GuardBarsMode GuardBarsMode { get; set; }
+
+        /// <summary>
+        /// Mode when rendering bearer bars
+        ///
+        /// Functionality not implemented for codes other than EAN-13
+        /// </summary>
+        public BearerBarsMode BearerBarsMode { get; set; }
 
         /// <summary>
         /// Gets or sets the amount of time in milliseconds that it took to encode and draw the barcode.
@@ -565,10 +575,16 @@ namespace BarcodeStandard
                             paint.ColorF = ForeColor;
 
                             //paint.Alignment = PenAlignment.Center;
-                            canvas.DrawLine(new SKPoint(0, 0), new SKPoint(bitmap.Width, 0), paint);//top
-                            canvas.DrawLine(new SKPoint(0, ilHeight), new SKPoint(bitmap.Width, ilHeight), paint);//bottom
-                            canvas.DrawLine(new SKPoint(0, 0), new SKPoint(0, ilHeight), paint);//left
-                            canvas.DrawLine(new SKPoint(bitmap.Width, 0), new SKPoint(bitmap.Width, ilHeight), paint);//right
+                            if (BearerBarsMode == BearerBarsMode.Frame || BearerBarsMode == BearerBarsMode.BearerBars)
+                            {
+                                canvas.DrawLine(new SKPoint(0, 0), new SKPoint(bitmap.Width, 0), paint);//top
+                                canvas.DrawLine(new SKPoint(0, ilHeight), new SKPoint(bitmap.Width, ilHeight), paint);//bottom
+                            }
+                            if (BearerBarsMode == BearerBarsMode.Frame)
+                            {
+                                canvas.DrawLine(new SKPoint(bitmap.Width, 0), new SKPoint(bitmap.Width, ilHeight), paint);//right
+                                canvas.DrawLine(new SKPoint(0, 0), new SKPoint(0, ilHeight), paint);//left
+                            }
                         }//using
 
                         if (IncludeLabel)

--- a/BarcodeStandard/Labels.cs
+++ b/BarcodeStandard/Labels.cs
@@ -82,7 +82,7 @@ namespace BarcodeLib
         /// <param name="barcode">Barcode to draw label for</param>
         /// <param name="img">Image representation of the barcode without the labels</param>
         /// <returns>Image representation of the barcode with labels applied</returns>
-        public static SKImage Label_Generic(Barcode barcode, SKBitmap img)
+        public static SKImage Label_Generic(Barcode barcode, SKBitmap img, int width)
         {
             try
             {
@@ -112,7 +112,7 @@ namespace BarcodeLib
                 foreBrush.MeasureText(text, ref textBounds);
                 var labelPadding = textBounds.Height / 2f;
 
-                var labelX = img.Width / 2f - textBounds.Width / 2f;
+                var labelX = alignmentAdjustment + ((width - textBounds.Width) / 2f);
                 var labelY = img.Height - textBounds.Height + labelPadding;
                 var backY = img.Height - textBounds.Height - labelPadding * 2f;
 

--- a/BarcodeStandard/Labels.cs
+++ b/BarcodeStandard/Labels.cs
@@ -346,5 +346,25 @@ namespace BarcodeLib
 
             return fontSize;
         }
+
+        internal static void TopBar(Barcode barcode, SKBitmap img, int shiftAdjustment, int barcodeWidth, int iBarWidth)
+        {
+            using (var g = new SKCanvas(img))
+            using (var foreBrush = new SKPaint())
+            using (var backBrush = new SKPaint())
+            {
+                foreBrush.ColorF = barcode.ForeColor;
+                foreBrush.IsAntialias = true;
+                foreBrush.StrokeWidth = iBarWidth;
+                backBrush.ColorF = barcode.BackColor;
+                backBrush.IsAntialias = true;
+
+                // Clear area under top bar
+                g.DrawRect(new SKRect(0, 0, img.Width, iBarWidth * 3), backBrush);
+
+                // Draw the top bar
+                g.DrawLine(new SKPoint(shiftAdjustment, iBarWidth * 1.5f), new SKPoint(shiftAdjustment + barcodeWidth, iBarWidth * 1.5f), foreBrush); 
+            }
+        }
     }
 }

--- a/BarcodeStandard/Labels.cs
+++ b/BarcodeStandard/Labels.cs
@@ -5,7 +5,7 @@ using BarcodeStandard;
 
 namespace BarcodeLib
 {
-    class Labels
+    internal class Labels
     {
         /// <summary>
         /// Draws Label for ITF-14 barcodes
@@ -22,7 +22,6 @@ namespace BarcodeLib
                 var str = barcode.AlternateLabel ?? barcode.RawData;
                 using (var foreBrush = new SKPaint(font))
                 {
-
                     SKRect textBounds = new();
                     foreBrush.MeasureText(str, ref textBounds);
                     var labelPadding = textBounds.Height / 2f;
@@ -97,7 +96,7 @@ namespace BarcodeLib
 
                 var alignmentAdjustment = BarcodeCommon.GetAlignmentShiftAdjustment(barcode);
                 var text = barcode.AlternateLabel ?? barcode.RawData;
-                    
+
                 //draw datastring under the barcode image
                 using var foreBrush = new SKPaint(barcode.LabelFont)
                 {
@@ -112,18 +111,18 @@ namespace BarcodeLib
                 SKRect textBounds = new();
                 foreBrush.MeasureText(text, ref textBounds);
                 var labelPadding = textBounds.Height / 2f;
-                    
+
                 var labelX = img.Width / 2f - textBounds.Width / 2f;
                 var labelY = img.Height - textBounds.Height + labelPadding;
                 var backY = img.Height - textBounds.Height - labelPadding * 2f;
-                        
+
                 //color a background color box at the bottom of the barcode to hold the string of data
                 using var backBrush = new SKPaint
                 {
                     ColorF = barcode.BackColor,
                     Style = SKPaintStyle.Fill
                 };
-                    
+
                 g.DrawRect(SKRect.Create(0, backY, img.Width, textBounds.Height + labelPadding * 2f), backBrush);
                 g.DrawText(text, labelX, labelY, foreBrush);
 
@@ -138,21 +137,20 @@ namespace BarcodeLib
                 throw new Exception("ELABEL_GENERIC-1: " + ex.Message);
             }//catch
         }
-        
+
         /// <summary>
         /// Draws Label for EAN-13 barcodes
         /// </summary>
         /// <param name="barcode">Barcode to draw label for.</param>
         /// <param name="img">Image representation of the barcode without the labels</param>
         /// <returns>Image representation of the barcode with labels applied</returns>
-        public static SKImage Label_EAN13(Barcode barcode, SKBitmap img)
+        public static SKImage Label_EAN13(Barcode barcode, SKBitmap img, int iBarWidth)
         {
             if (barcode == null) throw new ArgumentNullException(nameof(barcode));
             try
             {
-                var iBarWidth = barcode.Width / barcode.EncodedValue.Length;
-
                 var shiftAdjustment = BarcodeCommon.GetAlignmentShiftAdjustment(barcode);
+                var quietZoneAdjustment = BarcodeCommon.GetQuietZoneAdjustment(barcode);
 
                 barcode.LabelFont.Edging = SKFontEdging.SubpixelAntialias;
 
@@ -160,13 +158,13 @@ namespace BarcodeLib
                 var first = text.Substring(0, 1);
                 var second = text.Substring(1, 6);
                 var third = text.Substring(7, 6);
-                
+
                 using var g = new SKCanvas(img);
-                
+
                 using var foreBrush = new SKPaint(barcode.LabelFont);
                 SKRect textBounds = new();
                 foreBrush.MeasureText(text, ref textBounds);
-                
+
                 //Default alignment for UPCA
 
                 float w1 = iBarWidth * 3; //Width of first block
@@ -177,12 +175,12 @@ namespace BarcodeLib
                 var s2 = s1 + w1; //Start position of block 2
                 var s3 = s2 + w2 + iBarWidth * 5; //Start position of block 3
                 var s4 = s3 + w3;
-                
+
                 SKRect textBounds1 = new();
                 SKRect textBounds2 = new();
                 SKRect textBounds3 = new();
                 SKRect textBounds4 = new();
-                
+
                 foreBrush.MeasureText(first, ref textBounds1);
                 foreBrush.MeasureText(second, ref textBounds2);
                 foreBrush.MeasureText(third, ref textBounds3);
@@ -192,10 +190,13 @@ namespace BarcodeLib
                 {
                     backBrush.ColorF = barcode.BackColor;
                     backBrush.IsAntialias = true;
-                    
-                    g.DrawRect(new SKRect(s1, img.Height - textBounds1.Height - textBounds1.Height / 4f, s1 + w1, img.Height), backBrush); // first guard bar cover
+
+                    if (barcode.GuardBarsMode == GuardBarsMode.Enabled)
+                    {
+                        g.DrawRect(new SKRect(s1, img.Height - textBounds1.Height - textBounds1.Height / 4f, s1 + w1, img.Height), backBrush); // first guard bar cover
+                    }
                     g.DrawRect(new SKRect(s3, img.Height - textBounds3.Height * 2f, s3 + w3, img.Height), backBrush); // middle bar cover
-                    
+
                     g.DrawRect(new SKRect(s2 + w2, img.Height - textBounds4.Height - textBounds4.Height / 4f, s3, img.Height), backBrush);
                     g.DrawRect(new SKRect(s2, img.Height - textBounds2.Height * 2f, s2 + w2, img.Height), backBrush);
                 }
@@ -207,7 +208,15 @@ namespace BarcodeLib
                 foreBrush.IsAutohinted = true;
                 foreBrush.FilterQuality = SKFilterQuality.High;
 
-                g.DrawText(first, s1 + (w1 / 2f - textBounds1.Width / 2f), img.Height, foreBrush);
+                if (barcode.GuardBarsMode == GuardBarsMode.Enabled)
+                {
+                    g.DrawText(first, s1 + (w1 / 2f - textBounds1.Width / 2f), img.Height, foreBrush);
+                }
+                else if (barcode.GuardBarsMode == GuardBarsMode.EnabledFirstCharOnQuietZone)
+                {
+                    g.DrawText(first, s1 - quietZoneAdjustment, img.Height + textBounds2.MidY, foreBrush);
+                }
+
                 g.DrawText(second, s2 + (w2 / 2f - textBounds2.Width / 2f), img.Height + textBounds2.MidY, foreBrush);
                 g.DrawText(third, s3 + (w3 / 2f - textBounds3.Width / 2f), img.Height + textBounds3.MidY, foreBrush);
 
@@ -244,13 +253,13 @@ namespace BarcodeLib
                 var second = text.Substring(1, 5);
                 var third = text.Substring(6, 5);
                 var fourth = text.Substring(11);
-                
+
                 using var g = new SKCanvas(img);
-                
+
                 using var foreBrush = new SKPaint(barcode.LabelFont);
                 SKRect textBounds = new();
                 foreBrush.MeasureText(text, ref textBounds);
-                
+
                 //Default alignment for UPCA
 
                 float w1 = iBarWidth * 3; //Width of first block
@@ -262,12 +271,12 @@ namespace BarcodeLib
                 var s2 = s1 + w1; //Start position of block 2
                 var s3 = s2 + w2 + iBarWidth * 5; //Start position of block 3
                 var s4 = s3 + w3;
-                
+
                 SKRect textBounds1 = new();
                 SKRect textBounds2 = new();
                 SKRect textBounds3 = new();
                 SKRect textBounds4 = new();
-                
+
                 foreBrush.MeasureText(first, ref textBounds1);
                 foreBrush.MeasureText(second, ref textBounds2);
                 foreBrush.MeasureText(third, ref textBounds3);
@@ -278,11 +287,11 @@ namespace BarcodeLib
                 {
                     backBrush.ColorF = barcode.BackColor;
                     backBrush.IsAntialias = true;
-                    
+
                     g.DrawRect(new SKRect(s1, img.Height - textBounds1.Height - textBounds1.Height / 4f, s1 + w1, img.Height), backBrush); // first guard bar cover
                     g.DrawRect(new SKRect(s4, img.Height - textBounds4.Height - textBounds4.Height / 4f, s4 + w4, img.Height), backBrush); // end guard bar cover
                     g.DrawRect(new SKRect(s3, img.Height - textBounds3.Height * 2f, s3 + w3, img.Height), backBrush); // middle bar cover
-                    
+
                     g.DrawRect(new SKRect(s2 + w2, img.Height - textBounds4.Height - textBounds4.Height / 4f, s3, img.Height), backBrush);
                     g.DrawRect(new SKRect(s2, img.Height - textBounds2.Height * 2f, s2 + w2, img.Height), backBrush);
                 }
@@ -333,7 +342,6 @@ namespace BarcodeLib
                         }
                     }
                 }
-
             };
 
             return fontSize;

--- a/BarcodeStandard/Labels.cs
+++ b/BarcodeStandard/Labels.cs
@@ -37,8 +37,11 @@ namespace BarcodeLib
                             pen.ColorF = barcode.ForeColor;
                             pen.StrokeWidth = (float)img.Height / 16;
 
-                            canvas.DrawLine(new SKPoint(0, backY - pen.StrokeWidth / 2f),
-                                new SKPoint(img.Width, backY - pen.StrokeWidth / 2f), pen); //bottom
+                            if (barcode.BearerBarsMode != BearerBarsMode.Disabled)
+                            {
+                                canvas.DrawLine(new SKPoint(0, backY - pen.StrokeWidth / 2f),
+                                    new SKPoint(img.Width, backY - pen.StrokeWidth / 2f), pen); //bottom
+                            }
                         }
 
                         //color a box at the bottom of the barcode to hold the string of data

--- a/BarcodeStandard/Utils.cs
+++ b/BarcodeStandard/Utils.cs
@@ -14,5 +14,15 @@ namespace BarcodeStandard
                 return (int)textBounds.Height;
             }
         }
+
+        internal static int GetFontWidth(String text, SKFont font)
+        {
+            var textBounds = new SKRect();
+            using (var textPaint = new SKPaint(font))
+            {
+                textPaint.MeasureText(text, ref textBounds);
+                return (int)textBounds.Width;
+            }
+        }
     }
 }

--- a/BarcodeStandardExample/TestApp.Designer.cs
+++ b/BarcodeStandardExample/TestApp.Designer.cs
@@ -60,6 +60,8 @@ namespace BarcodeStandardExample
             this.txtHeight = new System.Windows.Forms.TextBox();
             this.label9 = new System.Windows.Forms.Label();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.label10 = new System.Windows.Forms.Label();
+            this.cbGuardBarsMode = new System.Windows.Forms.ComboBox();
             this.textBox1 = new System.Windows.Forms.TextBox();
             this.chkGenerateLabel = new System.Windows.Forms.CheckBox();
             this.label11 = new System.Windows.Forms.Label();
@@ -96,10 +98,10 @@ namespace BarcodeStandardExample
             this.tsslEncodedType,
             this.tslblLibraryVersion,
             this.tslblCredits});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 550);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 630);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(2, 0, 14, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(1015, 30);
+            this.statusStrip1.Size = new System.Drawing.Size(1015, 24);
             this.statusStrip1.SizingGrip = false;
             this.statusStrip1.TabIndex = 30;
             this.statusStrip1.Text = "statusStrip1";
@@ -108,20 +110,20 @@ namespace BarcodeStandardExample
             // 
             this.tsslEncodedType.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
             this.tsslEncodedType.Name = "tsslEncodedType";
-            this.tsslEncodedType.Size = new System.Drawing.Size(4, 24);
+            this.tsslEncodedType.Size = new System.Drawing.Size(4, 19);
             // 
             // tslblLibraryVersion
             // 
             this.tslblLibraryVersion.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
             this.tslblLibraryVersion.Name = "tslblLibraryVersion";
-            this.tslblLibraryVersion.Size = new System.Drawing.Size(825, 24);
+            this.tslblLibraryVersion.Size = new System.Drawing.Size(860, 19);
             this.tslblLibraryVersion.Spring = true;
             this.tslblLibraryVersion.Text = "LibVersion";
             // 
             // tslblCredits
             // 
             this.tslblCredits.Name = "tslblCredits";
-            this.tslblCredits.Size = new System.Drawing.Size(170, 24);
+            this.tslblCredits.Size = new System.Drawing.Size(135, 19);
             this.tslblCredits.Text = "Written by: Brad Barnhill";
             this.tslblCredits.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -131,7 +133,7 @@ namespace BarcodeStandardExample
             this.barcode.Dock = System.Windows.Forms.DockStyle.Fill;
             this.barcode.Location = new System.Drawing.Point(0, 0);
             this.barcode.Name = "barcode";
-            this.barcode.Size = new System.Drawing.Size(711, 550);
+            this.barcode.Size = new System.Drawing.Size(711, 630);
             this.barcode.TabIndex = 36;
             this.barcode.TabStop = false;
             this.barcode.Text = "Barcode Image";
@@ -139,7 +141,7 @@ namespace BarcodeStandardExample
             // btnMassGeneration
             // 
             this.btnMassGeneration.Location = new System.Drawing.Point(4, 16);
-            this.btnMassGeneration.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.btnMassGeneration.Margin = new System.Windows.Forms.Padding(2);
             this.btnMassGeneration.Name = "btnMassGeneration";
             this.btnMassGeneration.Size = new System.Drawing.Size(121, 33);
             this.btnMassGeneration.TabIndex = 0;
@@ -179,7 +181,7 @@ namespace BarcodeStandardExample
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.barcode);
-            this.splitContainer1.Size = new System.Drawing.Size(1015, 550);
+            this.splitContainer1.Size = new System.Drawing.Size(1015, 630);
             this.splitContainer1.SplitterDistance = 300;
             this.splitContainer1.TabIndex = 37;
             this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer1_SplitterMoved);
@@ -190,10 +192,10 @@ namespace BarcodeStandardExample
             this.groupBox2.Controls.Add(this.btnMassGeneration);
             this.groupBox2.Controls.Add(this.lblAverageGenerationTime);
             this.groupBox2.Controls.Add(this.label14);
-            this.groupBox2.Location = new System.Drawing.Point(8, 472);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBox2.Location = new System.Drawing.Point(8, 542);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(2);
             this.groupBox2.Size = new System.Drawing.Size(290, 80);
             this.groupBox2.TabIndex = 85;
             this.groupBox2.TabStop = false;
@@ -211,7 +213,7 @@ namespace BarcodeStandardExample
             this.lblAverageGenerationTime.AutoSize = true;
             this.lblAverageGenerationTime.Location = new System.Drawing.Point(136, 63);
             this.lblAverageGenerationTime.Name = "lblAverageGenerationTime";
-            this.lblAverageGenerationTime.Size = new System.Drawing.Size(0, 15);
+            this.lblAverageGenerationTime.Size = new System.Drawing.Size(0, 13);
             this.lblAverageGenerationTime.TabIndex = 81;
             // 
             // label14
@@ -219,7 +221,7 @@ namespace BarcodeStandardExample
             this.label14.AutoSize = true;
             this.label14.Location = new System.Drawing.Point(3, 63);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(152, 15);
+            this.label14.Size = new System.Drawing.Size(134, 13);
             this.label14.TabIndex = 80;
             this.label14.Text = "Average Generation Time: ";
             // 
@@ -232,10 +234,10 @@ namespace BarcodeStandardExample
             this.groupBox1.Controls.Add(this.btnSaveXML);
             this.groupBox1.Controls.Add(this.btnSave);
             this.groupBox1.Controls.Add(this.btnEncode);
-            this.groupBox1.Location = new System.Drawing.Point(8, 378);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBox1.Location = new System.Drawing.Point(8, 448);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
             this.groupBox1.Size = new System.Drawing.Size(282, 90);
             this.groupBox1.TabIndex = 84;
             this.groupBox1.TabStop = false;
@@ -244,9 +246,9 @@ namespace BarcodeStandardExample
             // 
             this.chkIncludeImageInSavedData.AutoSize = true;
             this.chkIncludeImageInSavedData.Location = new System.Drawing.Point(186, 70);
-            this.chkIncludeImageInSavedData.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.chkIncludeImageInSavedData.Margin = new System.Windows.Forms.Padding(2);
             this.chkIncludeImageInSavedData.Name = "chkIncludeImageInSavedData";
-            this.chkIncludeImageInSavedData.Size = new System.Drawing.Size(107, 19);
+            this.chkIncludeImageInSavedData.Size = new System.Drawing.Size(93, 17);
             this.chkIncludeImageInSavedData.TabIndex = 0;
             this.chkIncludeImageInSavedData.Text = "Include Image";
             this.chkIncludeImageInSavedData.UseVisualStyleBackColor = true;
@@ -347,7 +349,7 @@ namespace BarcodeStandardExample
             this.label13.AutoSize = true;
             this.label13.Location = new System.Drawing.Point(58, 50);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(72, 15);
+            this.label13.Size = new System.Drawing.Size(65, 13);
             this.label13.TabIndex = 53;
             this.label13.Text = "AspectRatio";
             // 
@@ -356,7 +358,7 @@ namespace BarcodeStandardExample
             this.label12.AutoSize = true;
             this.label12.Location = new System.Drawing.Point(8, 50);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(57, 15);
+            this.label12.Size = new System.Drawing.Size(51, 13);
             this.label12.TabIndex = 52;
             this.label12.Text = "BarWidth";
             // 
@@ -373,7 +375,7 @@ namespace BarcodeStandardExample
             this.label7.AutoSize = true;
             this.label7.Location = new System.Drawing.Point(16, 8);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(38, 15);
+            this.label7.Size = new System.Drawing.Size(35, 13);
             this.label7.TabIndex = 41;
             this.label7.Text = "Width";
             // 
@@ -382,7 +384,7 @@ namespace BarcodeStandardExample
             this.label6.AutoSize = true;
             this.label6.Location = new System.Drawing.Point(62, 8);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(43, 15);
+            this.label6.Size = new System.Drawing.Size(38, 13);
             this.label6.TabIndex = 42;
             this.label6.Text = "Height";
             // 
@@ -399,26 +401,50 @@ namespace BarcodeStandardExample
             this.label9.AutoSize = true;
             this.label9.Location = new System.Drawing.Point(53, 28);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(13, 15);
+            this.label9.Size = new System.Drawing.Size(12, 13);
             this.label9.TabIndex = 51;
             this.label9.Text = "x";
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.label10);
+            this.groupBox3.Controls.Add(this.cbGuardBarsMode);
             this.groupBox3.Controls.Add(this.textBox1);
             this.groupBox3.Controls.Add(this.chkGenerateLabel);
             this.groupBox3.Controls.Add(this.label11);
             this.groupBox3.Location = new System.Drawing.Point(164, 145);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(128, 77);
+            this.groupBox3.Size = new System.Drawing.Size(128, 144);
             this.groupBox3.TabIndex = 77;
             this.groupBox3.TabStop = false;
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Location = new System.Drawing.Point(3, 81);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(88, 13);
+            this.label10.TabIndex = 57;
+            this.label10.Text = "Guard bars mode";
+            // 
+            // cbGuardBarsMode
+            // 
+            this.cbGuardBarsMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbGuardBarsMode.FormattingEnabled = true;
+            this.cbGuardBarsMode.Items.AddRange(new object[] {
+            "Enabled",
+            "EnabledFirstCharOnQuietZone",
+            "Disabled"});
+            this.cbGuardBarsMode.Location = new System.Drawing.Point(4, 97);
+            this.cbGuardBarsMode.Name = "cbGuardBarsMode";
+            this.cbGuardBarsMode.Size = new System.Drawing.Size(118, 21);
+            this.cbGuardBarsMode.TabIndex = 56;
             // 
             // textBox1
             // 
             this.textBox1.Location = new System.Drawing.Point(4, 52);
             this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(102, 20);
+            this.textBox1.Size = new System.Drawing.Size(119, 20);
             this.textBox1.TabIndex = 54;
             // 
             // chkGenerateLabel
@@ -426,7 +452,7 @@ namespace BarcodeStandardExample
             this.chkGenerateLabel.AutoSize = true;
             this.chkGenerateLabel.Location = new System.Drawing.Point(6, 15);
             this.chkGenerateLabel.Name = "chkGenerateLabel";
-            this.chkGenerateLabel.Size = new System.Drawing.Size(110, 19);
+            this.chkGenerateLabel.Size = new System.Drawing.Size(95, 17);
             this.chkGenerateLabel.TabIndex = 40;
             this.chkGenerateLabel.Text = "Generate label";
             this.chkGenerateLabel.UseVisualStyleBackColor = true;
@@ -436,7 +462,7 @@ namespace BarcodeStandardExample
             this.label11.AutoSize = true;
             this.label11.Location = new System.Drawing.Point(3, 39);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(115, 15);
+            this.label11.Size = new System.Drawing.Size(102, 13);
             this.label11.TabIndex = 55;
             this.label11.Text = "Alternate Label Text";
             // 
@@ -445,7 +471,7 @@ namespace BarcodeStandardExample
             this.label8.AutoSize = true;
             this.label8.Location = new System.Drawing.Point(6, 93);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(62, 15);
+            this.label8.Size = new System.Drawing.Size(53, 13);
             this.label8.TabIndex = 74;
             this.label8.Text = "Alignment";
             // 
@@ -454,13 +480,13 @@ namespace BarcodeStandardExample
             this.label4.AutoSize = true;
             this.label4.Location = new System.Drawing.Point(7, 141);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(71, 15);
+            this.label4.Size = new System.Drawing.Size(61, 13);
             this.label4.TabIndex = 68;
             this.label4.Text = "Foreground";
             // 
             // txtEncoded
             // 
-            this.txtEncoded.Location = new System.Drawing.Point(7, 225);
+            this.txtEncoded.Location = new System.Drawing.Point(7, 295);
             this.txtEncoded.Multiline = true;
             this.txtEncoded.Name = "txtEncoded";
             this.txtEncoded.ReadOnly = true;
@@ -474,7 +500,7 @@ namespace BarcodeStandardExample
             this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(70, 141);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(73, 15);
+            this.label5.Size = new System.Drawing.Size(65, 13);
             this.label5.TabIndex = 69;
             this.label5.Text = "Background";
             // 
@@ -516,7 +542,7 @@ namespace BarcodeStandardExample
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(5, 209);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(90, 15);
+            this.label2.Size = new System.Drawing.Size(80, 13);
             this.label2.TabIndex = 64;
             this.label2.Text = "Encoded Value";
             // 
@@ -525,7 +551,7 @@ namespace BarcodeStandardExample
             this.lblEncodingTime.AutoSize = true;
             this.lblEncodingTime.Location = new System.Drawing.Point(89, 207);
             this.lblEncodingTime.Name = "lblEncodingTime";
-            this.lblEncodingTime.Size = new System.Drawing.Size(0, 15);
+            this.lblEncodingTime.Size = new System.Drawing.Size(0, 13);
             this.lblEncodingTime.TabIndex = 70;
             // 
             // label3
@@ -533,7 +559,7 @@ namespace BarcodeStandardExample
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(6, 48);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(59, 15);
+            this.label3.Size = new System.Drawing.Size(52, 13);
             this.label3.TabIndex = 65;
             this.label3.Text = "Encoding";
             // 
@@ -593,7 +619,7 @@ namespace BarcodeStandardExample
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(5, 8);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(96, 15);
+            this.label1.Size = new System.Drawing.Size(86, 13);
             this.label1.TabIndex = 63;
             this.label1.Text = "Value to Encode";
             // 
@@ -605,7 +631,7 @@ namespace BarcodeStandardExample
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1015, 580);
+            this.ClientSize = new System.Drawing.Size(1015, 654);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.statusStrip1);
             this.DoubleBuffered = true;
@@ -685,6 +711,8 @@ namespace BarcodeStandardExample
         private System.Windows.Forms.CheckBox chkIncludeImageInSavedData;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.ComboBox cbGuardBarsMode;
     }
 }
 

--- a/BarcodeStandardExample/TestApp.Designer.cs
+++ b/BarcodeStandardExample/TestApp.Designer.cs
@@ -79,6 +79,7 @@ namespace BarcodeStandardExample
             this.txtData = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+            this.chkTopBar = new System.Windows.Forms.CheckBox();
             this.statusStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -98,7 +99,7 @@ namespace BarcodeStandardExample
             this.tsslEncodedType,
             this.tslblLibraryVersion,
             this.tslblCredits});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 630);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 671);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(2, 0, 14, 0);
             this.statusStrip1.Size = new System.Drawing.Size(1015, 24);
@@ -133,7 +134,7 @@ namespace BarcodeStandardExample
             this.barcode.Dock = System.Windows.Forms.DockStyle.Fill;
             this.barcode.Location = new System.Drawing.Point(0, 0);
             this.barcode.Name = "barcode";
-            this.barcode.Size = new System.Drawing.Size(711, 630);
+            this.barcode.Size = new System.Drawing.Size(711, 671);
             this.barcode.TabIndex = 36;
             this.barcode.TabStop = false;
             this.barcode.Text = "Barcode Image";
@@ -181,7 +182,7 @@ namespace BarcodeStandardExample
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.barcode);
-            this.splitContainer1.Size = new System.Drawing.Size(1015, 630);
+            this.splitContainer1.Size = new System.Drawing.Size(1015, 671);
             this.splitContainer1.SplitterDistance = 300;
             this.splitContainer1.TabIndex = 37;
             this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer1_SplitterMoved);
@@ -192,7 +193,7 @@ namespace BarcodeStandardExample
             this.groupBox2.Controls.Add(this.btnMassGeneration);
             this.groupBox2.Controls.Add(this.lblAverageGenerationTime);
             this.groupBox2.Controls.Add(this.label14);
-            this.groupBox2.Location = new System.Drawing.Point(8, 542);
+            this.groupBox2.Location = new System.Drawing.Point(8, 586);
             this.groupBox2.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Padding = new System.Windows.Forms.Padding(2);
@@ -234,7 +235,7 @@ namespace BarcodeStandardExample
             this.groupBox1.Controls.Add(this.btnSaveXML);
             this.groupBox1.Controls.Add(this.btnSave);
             this.groupBox1.Controls.Add(this.btnEncode);
-            this.groupBox1.Location = new System.Drawing.Point(8, 448);
+            this.groupBox1.Location = new System.Drawing.Point(8, 492);
             this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
@@ -407,6 +408,7 @@ namespace BarcodeStandardExample
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.chkTopBar);
             this.groupBox3.Controls.Add(this.label10);
             this.groupBox3.Controls.Add(this.cbGuardBarsMode);
             this.groupBox3.Controls.Add(this.textBox1);
@@ -414,7 +416,7 @@ namespace BarcodeStandardExample
             this.groupBox3.Controls.Add(this.label11);
             this.groupBox3.Location = new System.Drawing.Point(164, 145);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(128, 144);
+            this.groupBox3.Size = new System.Drawing.Size(128, 193);
             this.groupBox3.TabIndex = 77;
             this.groupBox3.TabStop = false;
             // 
@@ -486,7 +488,7 @@ namespace BarcodeStandardExample
             // 
             // txtEncoded
             // 
-            this.txtEncoded.Location = new System.Drawing.Point(7, 295);
+            this.txtEncoded.Location = new System.Drawing.Point(7, 344);
             this.txtEncoded.Multiline = true;
             this.txtEncoded.Name = "txtEncoded";
             this.txtEncoded.ReadOnly = true;
@@ -540,7 +542,7 @@ namespace BarcodeStandardExample
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(5, 209);
+            this.label2.Location = new System.Drawing.Point(9, 325);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(80, 13);
             this.label2.TabIndex = 64;
@@ -627,11 +629,21 @@ namespace BarcodeStandardExample
             // 
             this.errorProvider1.ContainerControl = this;
             // 
+            // chkTopBar
+            // 
+            this.chkTopBar.AutoSize = true;
+            this.chkTopBar.Location = new System.Drawing.Point(6, 124);
+            this.chkTopBar.Name = "chkTopBar";
+            this.chkTopBar.Size = new System.Drawing.Size(63, 17);
+            this.chkTopBar.TabIndex = 58;
+            this.chkTopBar.Text = "Top bar";
+            this.chkTopBar.UseVisualStyleBackColor = true;
+            // 
             // TestApp
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1015, 654);
+            this.ClientSize = new System.Drawing.Size(1015, 695);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.statusStrip1);
             this.DoubleBuffered = true;
@@ -713,6 +725,7 @@ namespace BarcodeStandardExample
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.Label label10;
         private System.Windows.Forms.ComboBox cbGuardBarsMode;
+        private System.Windows.Forms.CheckBox chkTopBar;
     }
 }
 

--- a/BarcodeStandardExample/TestApp.Designer.cs
+++ b/BarcodeStandardExample/TestApp.Designer.cs
@@ -60,6 +60,7 @@ namespace BarcodeStandardExample
             this.txtHeight = new System.Windows.Forms.TextBox();
             this.label9 = new System.Windows.Forms.Label();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.chkTopBar = new System.Windows.Forms.CheckBox();
             this.label10 = new System.Windows.Forms.Label();
             this.cbGuardBarsMode = new System.Windows.Forms.ComboBox();
             this.textBox1 = new System.Windows.Forms.TextBox();
@@ -79,7 +80,8 @@ namespace BarcodeStandardExample
             this.txtData = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
-            this.chkTopBar = new System.Windows.Forms.CheckBox();
+            this.label15 = new System.Windows.Forms.Label();
+            this.cbBearerBarsMode = new System.Windows.Forms.ComboBox();
             this.statusStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -408,6 +410,8 @@ namespace BarcodeStandardExample
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.label15);
+            this.groupBox3.Controls.Add(this.cbBearerBarsMode);
             this.groupBox3.Controls.Add(this.chkTopBar);
             this.groupBox3.Controls.Add(this.label10);
             this.groupBox3.Controls.Add(this.cbGuardBarsMode);
@@ -419,6 +423,16 @@ namespace BarcodeStandardExample
             this.groupBox3.Size = new System.Drawing.Size(128, 193);
             this.groupBox3.TabIndex = 77;
             this.groupBox3.TabStop = false;
+            // 
+            // chkTopBar
+            // 
+            this.chkTopBar.AutoSize = true;
+            this.chkTopBar.Location = new System.Drawing.Point(6, 124);
+            this.chkTopBar.Name = "chkTopBar";
+            this.chkTopBar.Size = new System.Drawing.Size(63, 17);
+            this.chkTopBar.TabIndex = 58;
+            this.chkTopBar.Text = "Top bar";
+            this.chkTopBar.UseVisualStyleBackColor = true;
             // 
             // label10
             // 
@@ -629,15 +643,27 @@ namespace BarcodeStandardExample
             // 
             this.errorProvider1.ContainerControl = this;
             // 
-            // chkTopBar
+            // label15
             // 
-            this.chkTopBar.AutoSize = true;
-            this.chkTopBar.Location = new System.Drawing.Point(6, 124);
-            this.chkTopBar.Name = "chkTopBar";
-            this.chkTopBar.Size = new System.Drawing.Size(63, 17);
-            this.chkTopBar.TabIndex = 58;
-            this.chkTopBar.Text = "Top bar";
-            this.chkTopBar.UseVisualStyleBackColor = true;
+            this.label15.AutoSize = true;
+            this.label15.Location = new System.Drawing.Point(4, 143);
+            this.label15.Name = "label15";
+            this.label15.Size = new System.Drawing.Size(90, 13);
+            this.label15.TabIndex = 60;
+            this.label15.Text = "Bearer bars mode";
+            // 
+            // cbBearerBarsMode
+            // 
+            this.cbBearerBarsMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbBearerBarsMode.FormattingEnabled = true;
+            this.cbBearerBarsMode.Items.AddRange(new object[] {
+            "Frame",
+            "BearerBars",
+            "Disabled"});
+            this.cbBearerBarsMode.Location = new System.Drawing.Point(5, 159);
+            this.cbBearerBarsMode.Name = "cbBearerBarsMode";
+            this.cbBearerBarsMode.Size = new System.Drawing.Size(118, 21);
+            this.cbBearerBarsMode.TabIndex = 59;
             // 
             // TestApp
             // 
@@ -726,6 +752,8 @@ namespace BarcodeStandardExample
         private System.Windows.Forms.Label label10;
         private System.Windows.Forms.ComboBox cbGuardBarsMode;
         private System.Windows.Forms.CheckBox chkTopBar;
+        private System.Windows.Forms.Label label15;
+        private System.Windows.Forms.ComboBox cbBearerBarsMode;
     }
 }
 

--- a/BarcodeStandardExample/TestApp.cs
+++ b/BarcodeStandardExample/TestApp.cs
@@ -42,6 +42,7 @@ namespace BarcodeStandardExample
             var w = Convert.ToInt32(txtWidth.Text.Trim());
             var h = Convert.ToInt32(txtHeight.Text.Trim());
             _b.Alignment = AlignmentPositions.Center;
+            _b.IncludeTopBar = chkTopBar.Checked;
 
             //barcode alignment
             switch (cbBarcodeAlign.SelectedItem.ToString().Trim().ToLower())

--- a/BarcodeStandardExample/TestApp.cs
+++ b/BarcodeStandardExample/TestApp.cs
@@ -11,13 +11,13 @@ namespace BarcodeStandardExample
 {
     /// <summary>
     /// This form is a test form to show what all you can do with the Barcode Library.
-    /// Only one call is actually needed to do the encoding and return the image of the 
+    /// Only one call is actually needed to do the encoding and return the image of the
     /// barcode but the rest is just flare and user interface ... stuff.
     /// </summary>
     public partial class TestApp : Form
     {
-        Barcode _b = new Barcode();
-        
+        private Barcode _b = new Barcode();
+
         public TestApp()
         {
             InitializeComponent();
@@ -27,6 +27,7 @@ namespace BarcodeStandardExample
         {
             cbEncodeType.SelectedIndex = 0;
             cbBarcodeAlign.SelectedIndex = 0;
+            cbGuardBarsMode.SelectedIndex = 0;
 
             //Show library version
             tslblLibraryVersion.Text = @"Barcode Library Version: " + Barcode.Version;
@@ -48,6 +49,14 @@ namespace BarcodeStandardExample
                 case "left": _b.Alignment = AlignmentPositions.Left; break;
                 case "right": _b.Alignment = AlignmentPositions.Right; break;
                 default: _b.Alignment = AlignmentPositions.Center; break;
+            }//switch
+
+            //guard bars mode
+            switch (cbGuardBarsMode.SelectedItem.ToString().Trim().ToLower())
+            {
+                case "disabled": _b.GuardBarsMode = GuardBarsMode.Disabled; break;
+                case "enabledfirstcharonquietzone": _b.GuardBarsMode = GuardBarsMode.EnabledFirstCharOnQuietZone; break;
+                default: _b.GuardBarsMode = GuardBarsMode.Enabled; break;
             }//switch
 
             var type = GetTypeSelected();
@@ -82,10 +91,10 @@ namespace BarcodeStandardExample
                     //===== Encoding performed here =====
                     barcode.BackgroundImage = Image.FromStream(_b.Encode(type, txtData.Text.Trim(), _b.ForeColor, _b.BackColor, w, h).Encode().AsStream());
                     //===================================
-                    
+
                     //show the encoding time
                     lblEncodingTime.Text = @"(" + Math.Round(_b.EncodingTime, 0, MidpointRounding.AwayFromZero) + @"ms)";
-                    
+
                     txtEncoded.Text = _b.EncodedValue;
 
                     tsslEncodedType.Text = @"Encoding Type: " + _b.EncodedType;
@@ -298,50 +307,65 @@ namespace BarcodeStandardExample
                 case "UPCA":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("UPC-A");
                     break;
+
                 case "UCC13":
                 case "EAN13":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("EAN-13");
                     break;
+
                 case "Interleaved2of5_Mod10":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Interleaved 2 of 5 Mod 10");
                     break;
+
                 case "Interleaved2of5":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Interleaved 2 of 5");
                     break;
+
                 case "Standard2of5_Mod10":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Standard 2 of 5 Mod 10");
                     break;
+
                 case "Standard2of5":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Standard 2 of 5");
                     break;
+
                 case "LOGMARS":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("LOGMARS");
                     break;
+
                 case "CODE39":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Code 39");
                     break;
+
                 case "CODE39Extended":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Code 39 Extended");
                     break;
+
                 case "CODE39_Mod43":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Code 39 Mod 43");
                     break;
+
                 case "Codabar":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Codabar");
                     break;
+
                 case "PostNet":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("PostNet");
                     break;
+
                 case "ISBN":
                 case "BOOKLAND":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Bookland/ISBN");
                     break;
+
                 case "JAN13":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("JAN-13");
                     break;
+
                 case "UPC_SUPPLEMENTAL_2DIGIT":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("UPC 2 Digit Ext.");
                     break;
+
                 case "MSI_Mod10":
                 case "MSI_2Mod10":
                 case "MSI_Mod11":
@@ -349,40 +373,52 @@ namespace BarcodeStandardExample
                 case "Modified_Plessey":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("MSI");
                     break;
+
                 case "UPC_SUPPLEMENTAL_5DIGIT":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("UPC 5 Digit Ext.");
                     break;
+
                 case "UPCE":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("UPC-E");
                     break;
+
                 case "EAN8":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("EAN-8");
                     break;
+
                 case "USD8":
                 case "CODE11":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Code 11");
                     break;
+
                 case "CODE128":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Code 128");
                     break;
+
                 case "CODE128A":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Code 128-A");
                     break;
+
                 case "CODE128B":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Code 128-B");
                     break;
+
                 case "CODE128C":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Code 128-C");
                     break;
+
                 case "ITF14":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("ITF-14");
                     break;
+
                 case "CODE93":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Code 93");
                     break;
+
                 case "FIM":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("FIM");
                     break;
+
                 case "Pharmacode":
                     cbEncodeType.SelectedIndex = cbEncodeType.FindString("Pharmacode");
                     break;

--- a/BarcodeStandardExample/TestApp.cs
+++ b/BarcodeStandardExample/TestApp.cs
@@ -28,6 +28,7 @@ namespace BarcodeStandardExample
             cbEncodeType.SelectedIndex = 0;
             cbBarcodeAlign.SelectedIndex = 0;
             cbGuardBarsMode.SelectedIndex = 0;
+            cbBearerBarsMode.SelectedIndex = 0;
 
             //Show library version
             tslblLibraryVersion.Text = @"Barcode Library Version: " + Barcode.Version;
@@ -58,6 +59,14 @@ namespace BarcodeStandardExample
                 case "disabled": _b.GuardBarsMode = GuardBarsMode.Disabled; break;
                 case "enabledfirstcharonquietzone": _b.GuardBarsMode = GuardBarsMode.EnabledFirstCharOnQuietZone; break;
                 default: _b.GuardBarsMode = GuardBarsMode.Enabled; break;
+            }//switch
+
+            //bearer bars mode
+            switch (cbBearerBarsMode.SelectedItem.ToString().Trim().ToLower())
+            {
+                case "disabled": _b.BearerBarsMode = BearerBarsMode.Disabled; break;
+                case "bearerbars": _b.BearerBarsMode = BearerBarsMode.BearerBars; break;
+                default: _b.BearerBarsMode = BearerBarsMode.Frame; break;
             }//switch
 
             var type = GetTypeSelected();


### PR DESCRIPTION
This PR adds support for including top bar when rendering barcodes and configurable bearer bar mode for ITF-14.

# Top-bar off (default)
![EAN13_TopBar_Off](https://github.com/barnhill/barcodelib/assets/1384600/e59bc985-f261-4625-b549-a2fbfd70b0ad)

# Top bar enabled
![EAN13_TopBar_On](https://github.com/barnhill/barcodelib/assets/1384600/2b1b97b5-bd12-4324-b610-16250c736367)

# ITF-14 Bearer mode: frame (default)
![ITF14_BearerBar_Frame](https://github.com/barnhill/barcodelib/assets/1384600/f903e307-a8c2-4de1-89ab-3d263fb46396)

# ITF-14 Bearer mode: bearer bars
![ITF14_BearerBar](https://github.com/barnhill/barcodelib/assets/1384600/23afca05-36b1-4a53-9c1c-3bb79c3f2d65)

# ITF-14 Bearer mode: disabled
![ITF14_BearerBar_Disabled](https://github.com/barnhill/barcodelib/assets/1384600/27086fd5-da67-4418-9c78-d229ee2cc431)
